### PR TITLE
Update gitignore and add a gdignore to the imgs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,17 @@
-*.import
-*.png
 
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
 
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+# System/tool-specific ignores
+.directory
+*~


### PR DESCRIPTION
The gitignore was missing a few things and had a few strange ignores. The `.import/` folder should be ignored, but not `*.import` files. I have no idea why `*.png` was ignored.

The `.gdignore` prevents Godot from importing the `imgs/` folder.