### PR TITLE
Using free() instead of queue_free()

### DIFF
--- a/addons/easy_charts/Utilities/Scripts/chart.gd
+++ b/addons/easy_charts/Utilities/Scripts/chart.gd
@@ -468,11 +468,10 @@ func count_functions():
 	else: functions = y_datas.size()
 
 func clear_points():
-	if $Points.get_children():
-		for function in Points.get_children():
-			function.queue_free()
-	for legend in $Legend.get_children():
-		legend.queue_free()
+	for function in Points.get_children():
+		function.free()
+	for legend in Legend.get_children():
+		legend.free()
 
 func redraw():
 	build_chart()


### PR DESCRIPTION
changed to free() since queue_free() is not fast enough. Godot Doc: "Queues a node for deletion at the end of the current frame."
When changing the size of the Window it gets called multiple times a frame and ends up creating multiple points which end up being invalid.