### PR TITLE
Remove existing function_plotter nodes before loading new functions

### DIFF
--- a/addons/easy_charts/control_charts/chart.gd
+++ b/addons/easy_charts/control_charts/chart.gd
@@ -57,6 +57,11 @@ func load_functions(functions: Array[Function]) -> void:
 	self.y = []
 	
 	function_legend.clear()
+
+	# Remove existing function_plotters
+	for function_plotter in functions_box.get_children():
+		functions_box.remove_child(function_plotter)
+		function_plotter.queue_free()
 	
 	for function in functions:
 		# Load x and y values


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fixes an issue with old functions being drawn when calling plot multiple times with different functions on the same graph.
Fixes https://github.com/fenix-hub/godot-engine.easy-charts/issues/91
