### PR TITLE
Fix bar chart references to function x and y, Fix x axis labels and y axis not starting at zero

### DIFF
--- a/addons/easy_charts/control_charts/chart.gd
+++ b/addons/easy_charts/control_charts/chart.gd
@@ -63,6 +63,11 @@ func load_functions(functions: Array[Function]) -> void:
 		self.x.append(function.__x)
 		self.y.append(function.__y)
 		
+		# Load Labels
+		if self.x_labels.is_empty():
+			if ECUtilities._contains_string(function.__x):
+				self.x_labels = function.__x
+		
 		# Create FunctionPlotter
 		var function_plotter: FunctionPlotter = get_function_plotter(function)
 		function_plotter.connect("point_entered", Callable(plot_box, "_on_point_entered"))

--- a/addons/easy_charts/control_charts/plotters/bar_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/bar_plotter.gd
@@ -26,10 +26,10 @@ func _draw() -> void:
 func sample(x_sampled_domain: Dictionary, y_sampled_domain: Dictionary) -> void:
 	bars = []
 	bars_rects = []
-	for i in function.x.size():
+	for i in function.__x.size():
 		var top: Vector2 = Vector2(
 			ECUtilities._map_domain(i, x_domain, x_sampled_domain),
-			ECUtilities._map_domain(function.y[i], y_domain, y_sampled_domain)
+			ECUtilities._map_domain(function.__y[i], y_domain, y_sampled_domain)
 		)
 		var base: Vector2 = Vector2(top.x, ECUtilities._map_domain(0.0, y_domain, y_sampled_domain))
 		bars.push_back(top)
@@ -44,7 +44,7 @@ func _input(event: InputEvent) -> void:
 	if event is InputEventMouse:
 		for i in bars_rects.size():
 			if bars_rects[i].grow(5).abs().has_point(get_relative_position(event.position)):
-				var point: Point = Point.new(bars_rects[i].get_center(), { x = function.x[i], y = function.y[i]})
+				var point: Point = Point.new(bars_rects[i].get_center(), { x = function.__x[i], y = function.__y[i]})
 				if focused_bar_midpoint == point:
 					return
 				else:

--- a/addons/easy_charts/utilities/scripts/ec_utilities.gd
+++ b/addons/easy_charts/utilities/scripts/ec_utilities.gd
@@ -45,7 +45,7 @@ static func _find_min_max(values: Array) -> Dictionary:
 	for dim in temp:
 		min_ts.append(dim.min())
 		max_ts.append(dim.max())
-	_min = min_ts.min()
+	_min = min(min_ts.min(), 0)
 	_max = max(0, max_ts.max())
 	
 	return { min = _min, max = _max }


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR fixes three bugs:
1. bar chart using wrong references to function x and y
2. labels on the bar chart for the x axis not being displayed
3. y axis of the bar chart starts again at zero

Fixes #93 
Fixes #94 

## Additional context
Old: 
![Screenshot 2023-10-05 135705](https://github.com/fenix-hub/godot-engine.easy-charts/assets/5958083/192cff65-6c79-4285-8872-c80c8fbe4160)

New:
![Screenshot 2023-10-05 135726](https://github.com/fenix-hub/godot-engine.easy-charts/assets/5958083/ac686ccf-7f1e-4646-9945-618468629111)


