### PR TITLE
Discrete scatter chart example + function moved

### DIFF
--- a/addons/easy_charts/control_charts/chart.gd
+++ b/addons/easy_charts/control_charts/chart.gd
@@ -37,21 +37,6 @@ func plot(functions: Array[Function], properties: ChartProperties = ChartPropert
 
 	load_functions(functions)
 
-func get_function_plotter(function: Function) -> FunctionPlotter:
-	var plotter: FunctionPlotter
-	match function.get_type():
-		Function.Type.LINE:
-			plotter = LinePlotter.new(function)
-		Function.Type.AREA:
-			plotter = AreaPlotter.new(function)
-		Function.Type.PIE:
-			plotter = PiePlotter.new(function)
-		Function.Type.BAR:
-			plotter = BarPlotter.new(function)
-		Function.Type.SCATTER, _:
-			plotter = ScatterPlotter.new(function)
-	return plotter
-
 func load_functions(functions: Array[Function]) -> void:
 	self.x = []
 	self.y = []
@@ -69,7 +54,7 @@ func load_functions(functions: Array[Function]) -> void:
 		self.y.append(function.__y)
 
 		# Create FunctionPlotter
-		var function_plotter: FunctionPlotter = get_function_plotter(function)
+		var function_plotter := FunctionPlotter.create_for_function(function)
 		function_plotter.connect("point_entered", Callable(plot_box, "_on_point_entered"))
 		function_plotter.connect("point_exited", Callable(plot_box, "_on_point_exited"))
 		functions_box.add_child(function_plotter)

--- a/addons/easy_charts/control_charts/plotters/function_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/function_plotter.gd
@@ -5,28 +5,41 @@ var function: Function
 var x_domain: Dictionary
 var y_domain: Dictionary
 
+static func create_for_function(function: Function) -> FunctionPlotter:
+	match function.get_type():
+		Function.Type.LINE:
+			return LinePlotter.new(function)
+		Function.Type.AREA:
+			return AreaPlotter.new(function)
+		Function.Type.PIE:
+			return PiePlotter.new(function)
+		Function.Type.BAR:
+			return BarPlotter.new(function)
+		Function.Type.SCATTER, _:
+			return ScatterPlotter.new(function)
+
 func _init(function: Function) -> void:
-    self.function = function
+	self.function = function
 
 func _ready() -> void:
-    set_process_input(get_chart_properties().interactive)
+	set_process_input(get_chart_properties().interactive)
 
 func update_values(x_domain: Dictionary, y_domain: Dictionary) -> void:
-    self.visible = self.function.get_visibility()
-    if not self.function.get_visibility():
-        return
-    self.x_domain = x_domain
-    self.y_domain = y_domain
-    queue_redraw()
+	self.visible = self.function.get_visibility()
+	if not self.function.get_visibility():
+		return
+	self.x_domain = x_domain
+	self.y_domain = y_domain
+	queue_redraw()
 
 func _draw() -> void:
-    return
+	return
 
 func get_box() -> Rect2:
-    return get_parent().get_parent().get_plot_box()
+	return get_parent().get_parent().get_plot_box()
 
 func get_chart_properties() -> ChartProperties:
-    return get_parent().get_parent().chart_properties
+	return get_parent().get_parent().chart_properties
 
 func get_relative_position(position: Vector2) -> Vector2:
-    return position - global_position
+	return position - global_position

--- a/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd
+++ b/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd
@@ -45,10 +45,10 @@ func _ready():
 
 	# Configure the x axis so that there is one tick every two hours. This has to
 	# be precise to ensure that no interpolation happens
-	cp.x_scale = x.size() / 2 - 1
+	cp.x_scale = x.size() - 1
 	chart.set_x_domain(0, x.size() - 1)
 	chart.x_labels_function = func(value: float) -> String:
-		return "%02d:00 - %02d:00" % [value, value + 1]
+		return "%2d h" % round(value)
 
 	# Configure the y axis 
 	var y_max_value := 0

--- a/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd
+++ b/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd
@@ -1,0 +1,64 @@
+extends Control
+
+@onready var chart: Chart = $VBoxContainer/Chart
+
+# This Chart will plot 3 different functions
+var f1: Function
+var f2: Function
+
+func _ready():
+	# Let's create our @x values
+	var x: Array = ["City 1", "City 2", "City 3", "City 4", "City 5"]
+ 
+	# And our y values. It can be an n-size array of arrays.
+	# NOTE: `x.size() == y.size()` or `x.size() == y[n].size()`
+	var y: Array = [10, 15, 4, 8, 15]
+
+	# Let's customize the chart properties, which specify how the chart
+	# should look, plus some additional elements like labels, the scale, etc...
+	var cp: ChartProperties = ChartProperties.new()
+	cp.colors.frame = Color("#161a1d")
+	cp.colors.background = Color.TRANSPARENT
+	cp.colors.grid = Color("#283442")
+	cp.colors.ticks = Color("#283442")
+	cp.colors.text = Color.WHITE_SMOKE
+	cp.draw_bounding_box = false
+	cp.title = "Population chart"
+	cp.x_label = "Cities"
+	cp.y_label = "Inhabitants"
+	cp.x_scale = 5
+	cp.y_scale = 10
+	cp.interactive = true # false by default, it allows the chart to create a tooltip to show point values
+	# and interecept clicks on the plot
+ 
+	# Let's add values to our functions
+	f1 = Function.new(
+		x, y, "Foo", # This will create a function with x and y values taken by the Arrays 
+					# we have created previously. This function will also be named "Pressure"
+					# as it contains 'pressure' values.
+					# If set, the name of a function will be used both in the Legend
+					# (if enabled thourgh ChartProperties) and on the Tooltip (if enabled).
+		{ color = Color.GREEN, marker = Function.Marker.CIRCLE }
+	)
+
+	# Now let's plot our data
+	chart.plot([f1], cp)
+
+	# Uncommenting this line will show how real time data plotting works
+	set_process(false)
+
+
+var new_val: float = 4.5
+
+func _process(delta: float):
+	# This function updates the values of a function and then updates the plot
+	new_val += 5
+
+	# we can use the `Function.add_point(x, y)` method to update a function
+	f1.add_point(new_val, cos(new_val) * 20)
+	f2.add_point(new_val, (sin(new_val) * 20) + 20)
+	chart.queue_redraw() # This will force the Chart to be updated
+
+
+func _on_CheckButton_pressed():
+	set_process(not is_processing())

--- a/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd.uid
+++ b/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd.uid
@@ -1,0 +1,1 @@
+uid://cwjc16brbjkia

--- a/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.tscn
+++ b/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=4 format=3 uid="uid://duq43d7ll1aah"]
+
+[ext_resource type="Script" uid="uid://cwjc16brbjkia" path="res://addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd" id="1_3npap"]
+[ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2_pd01x"]
+
+[sub_resource type="StyleBoxFlat" id="1"]
+content_margin_right = 5.0
+content_margin_bottom = 5.0
+draw_center = false
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0, 0, 0, 1)
+
+[node name="Control2" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_3npap")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="CheckButton" type="CheckButton" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
+theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
+text = "Start Relatime Plotting"
+
+[node name="Chart" parent="VBoxContainer" instance=ExtResource("2_pd01x")]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 8
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_styles/normal = SubResource("1")
+text = "Try to scale the window!"
+
+[connection signal="pressed" from="VBoxContainer/CheckButton" to="." method="_on_CheckButton_pressed"]

--- a/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.tscn
+++ b/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.tscn
@@ -25,16 +25,6 @@ layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 
-[node name="CheckButton" type="CheckButton" parent="VBoxContainer"]
-layout_mode = 2
-theme_override_colors/font_disabled_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_pressed_color = Color(0, 0, 0, 1)
-theme_override_colors/font_hover_color = Color(0, 0, 0, 1)
-theme_override_colors/font_color = Color(0, 0, 0, 1)
-theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
-theme_override_colors/font_pressed_color = Color(0, 0, 0, 1)
-text = "Start Relatime Plotting"
-
 [node name="Chart" parent="VBoxContainer" instance=ExtResource("2_pd01x")]
 layout_mode = 2
 
@@ -44,5 +34,3 @@ size_flags_horizontal = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_styles/normal = SubResource("1")
 text = "Try to scale the window!"
-
-[connection signal="pressed" from="VBoxContainer/CheckButton" to="." method="_on_CheckButton_pressed"]


### PR DESCRIPTION
## What kind of change does this PR introduce?

For another project, I was searching on how to configure scatter charts with custom labels and discrete scaling of x and y ticks. This may be helpful for others, since it's not super intuitive on how this can be done at the moment. Therefore, this PR introduces a new example that demonstrates how to configure a scatter chart with following axes:

- The x-axis has a domain and scale configured to print discrete string labels via a `x_labels_function`. The labels represent time ranges, e.g. "02:00 - 03:00" for "between 2 and 3 o'clock"
- The y-axis has a domain and scale configured to show only discrete values. In this example, the y values represent integer counts.

Screenshot of the result:

![image](https://github.com/user-attachments/assets/b71ae0de-d8fb-44c7-a086-50ebabc6fbdb)

The label rendering is not optimal but there is an issue open for fixing it.

In addition, while trying to figure out how things work, I moved the "get function plotter" method into a factory function `FunctionPlotter.create_for_function(Function)`.

One final remark on white spaces: It seems that some files use a different indent than others. It may make sense to file a new PR that aligns the indention of all files.