### PR TITLE
Add project file and configure git archiving

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize line endings for all files that Git considers text files.
+* text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 default_env.tres
 /icon.png
 /icon.png.import
-project.godot
 scn/
 /screenshot.png
 /snapshot.png

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,20 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="godot-engine.easy-charts"
+config/features=PackedStringArray("4.4", "GL Compatibility")
+config/icon="res://icon.svg"
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes #114.

## What is the current behavior?

1. There is no project.godot file included which makes it harder for contributors to start working on the project.
2. There was no .gitattributes configuring the archiving behavior. This means, ZIP archives downloaded from github and installation via Godot asset library included non-addon files.


## What is the new behavior?

1. Godot project files is included. Devs can clone the repository and open the project in Godot without additional work.
2. Only the addon directory is included in ZIP archives from both, Github as well as the Godot asset library. There are no more file conflicts with project files of users that want to use easy charts.

## Additional context

The .gitattributes config is explained in detail here: https://docs.godotengine.org/en/stable/community/asset_library/submitting_to_assetlib.html
