### PR TITLE
Fix performance issue when setting large domains

### DIFF
--- a/addons/easy_charts/control_charts/chart.gd
+++ b/addons/easy_charts/control_charts/chart.gd
@@ -126,10 +126,10 @@ func calculate_domain(values: Array) -> Dictionary:
         return { lb = ECUtilities._round_min(min_max.min), ub = ECUtilities._round_max(min_max.max), has_decimals = ECUtilities._has_decimals(values) , fixed = false }
 
 func set_x_domain(lb: Variant, ub: Variant) -> void:
-    x_domain = { lb = lb, ub = ub, has_decimals = ECUtilities._has_decimals([lb, ub]), fixed = true }
+    x_domain = { lb = lb, ub = ub, has_decimals = ECUtilities._has_decimals([[lb, ub]]), fixed = true }
 
 func set_y_domain(lb: Variant, ub: Variant) -> void:
-    y_domain = { lb = lb, ub = ub, has_decimals = ECUtilities._has_decimals([lb, ub]), fixed = true }
+    y_domain = { lb = lb, ub = ub, has_decimals = ECUtilities._has_decimals([[lb, ub]]), fixed = true }
 
 func update_plotbox(x_domain: Dictionary, y_domain: Dictionary, x_labels_function: Callable, y_labels_function: Callable) -> void:
     plot_box.box_margins = calculate_plotbox_margins(x_domain, y_domain, y_labels_function)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The  `_has_decimals()` function of `ECUtilities` is currently:
```gdscript
static func _has_decimals(values: Array) -> bool:
    var temp: Array = values.duplicate(true)
    
    for dim in temp:
        for val in dim:
            if val is String:
                return false
            if abs(fmod(val, 1)) > 0.0:
                return true
    
    return false
```
It is called from the `set_x_domain` and `set_y_domain` functions of the Chart class, passing a lower bound, upper bound pair (`[lb, ub]`).

`_has_decimals` is iterating over the array, and then iterating over all array children (presumably to support checking nested arrays of values). However, if it is only being passed a single array pair of numbers (as is the case in the `set_*_domain` functions), the nested for loop will be asked to iterate over a number instead of an array. For instance, if I set the y domain to `[0, 1e12]`:
```gdscript
for val in 1e12:
	...
```
will execute for the upper bound, and will (try to) iterate for all integers from 0 all the way to 1e12, causing a crash.


## What is the new behavior?

I opted to just nest the lower and upper bounds in a second array so the behavior of `_has_decimals` (and `calculate_domain` in the Chart class) wouldn't need to be modified:

```gdscript
func set_x_domain(lb: Variant, ub: Variant) -> void:
	x_domain = { lb = lb, ub = ub, has_decimals = ECUtilities._has_decimals([[lb, ub]]), fixed = true }

func set_y_domain(lb: Variant, ub: Variant) -> void:
	y_domain = { lb = lb, ub = ub, has_decimals = ECUtilities._has_decimals([[lb, ub]]), fixed = true }
```
