### PR TITLE
Discrete (string) domain handling and refactored tooltip handling

### DIFF
--- a/addons/easy_charts/control_charts/chart.gd
+++ b/addons/easy_charts/control_charts/chart.gd
@@ -8,6 +8,9 @@ class_name Chart
 @onready var functions_box: Control = %FunctionsBox
 @onready var function_legend: FunctionLegend = %FunctionLegend
 
+@onready var _tooltip: DataTooltip = %Tooltip
+var _function_of_tooltip: Function = null
+
 var functions: Array = []
 var x: Array = []
 var y: Array = []
@@ -55,8 +58,8 @@ func load_functions(functions: Array[Function]) -> void:
 
 		# Create FunctionPlotter
 		var function_plotter := FunctionPlotter.create_for_function(function)
-		function_plotter.connect("point_entered", Callable(plot_box, "_on_point_entered"))
-		function_plotter.connect("point_exited", Callable(plot_box, "_on_point_exited"))
+		function_plotter.point_entered.connect(_show_tooltip)
+		function_plotter.point_exited.connect(_hide_tooltip)
 		functions_box.add_child(function_plotter)
 
 		# Create legend
@@ -100,6 +103,18 @@ func _draw() -> void:
 				x_domain = ChartAxisDomain.from_values(x, chart_properties.smooth_domain)
 			if not is_y_fixed:
 				y_domain = ChartAxisDomain.from_values(y, chart_properties.smooth_domain)
+	
+	if !x_domain.is_discrete:
+		x_domain.set_tick_count(chart_properties.x_scale)
+
+	if x_labels_function:
+		x_domain.labels_function = x_labels_function
+
+	if !y_domain.is_discrete:
+		y_domain.set_tick_count(chart_properties.y_scale)
+
+	if y_labels_function:
+		y_domain.labels_function = y_labels_function
 
 	# Update values for the PlotBox in order to propagate them to the children
 	update_plotbox(x_domain, y_domain, x_labels_function, y_labels_function)
@@ -159,3 +174,19 @@ func _on_plot_box_resized() -> void:
 	grid_box.queue_redraw()
 	for function in functions_box.get_children():
 		function.queue_redraw()
+
+func _show_tooltip(point: Point, function: Function, options: Dictionary = {}) -> void:
+	var x_value: String = x_domain.get_tick_label(point.value.x, x_labels_function)
+	var y_value: String = y_domain.get_tick_label(point.value.y, y_labels_function)
+	var color: Color = function.get_color() if function.get_type() != Function.Type.PIE \
+		else function.get_gradient().sample(options.interpolation_index)
+	_tooltip.show()
+	_tooltip.update_values(x_value, y_value, function.name, color)
+	_tooltip.update_position(point.position)
+	_function_of_tooltip = function
+
+func _hide_tooltip(point: Point, function: Function) -> void:
+	if function != _function_of_tooltip:
+		return
+
+	_tooltip.hide()

--- a/addons/easy_charts/control_charts/plotters/bar_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/bar_plotter.gd
@@ -28,8 +28,8 @@ func sample(x_sampled_domain: ChartAxisDomain, y_sampled_domain: ChartAxisDomain
 	bars_rects = []
 	for i in function.__x.size():
 		var top: Vector2 = Vector2(
-			ECUtilities._map_domain(i, x_domain, x_sampled_domain),
-			ECUtilities._map_domain(function.__y[i], y_domain, y_sampled_domain)
+			x_domain.map_to(i, function.__x, x_sampled_domain),
+			y_domain.map_to(i, function.__y, y_sampled_domain)
 		)
 		var base: Vector2 = Vector2(top.x, ECUtilities._map_domain(0.0, y_domain, y_sampled_domain))
 		bars.push_back(top)

--- a/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
@@ -32,9 +32,9 @@ func sample(x_sampled_domain: ChartAxisDomain, y_sampled_domain: ChartAxisDomain
 	points = []
 	points_positions = []
 	var lower_bound: int = max(0, function.__x.size() - get_chart_properties().max_samples) \
-	#disable sample display limits
-	if get_chart_properties().max_samples > 0 \
-	else 0
+		if get_chart_properties().max_samples > 0 \
+		else 0
+
 	for i in range(lower_bound, function.__x.size()):
 		var _position: Vector2 = Vector2(
 			ECUtilities._map_domain(float(function.__x[i]), x_domain, x_sampled_domain),

--- a/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd
+++ b/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd
@@ -4,7 +4,7 @@ extends Control
 
 func _ready():
 	# X values will be the hours of the day, starting with 0 ending on 23.
-	var x: Array = range(0, 24)
+	var x: Array = range(0, 24).map(func(i) -> String: return "%d - %d h" % [i, i+1])
 
 	# Arrays contain how many animals have been seen in each hour.
 	var blackbird_spots: Array =   [0, 0, 0, 0, 0, 0, 0, 4, 5, 3, 6, 0, 0, 0, 2, 0, 0, 4, 5, 0, 0, 0, 0, 0]
@@ -40,17 +40,9 @@ func _ready():
 		{ color = Color.BLUE, marker = Function.Marker.CROSS, type = Function.Type.SCATTER }
 	)
 
-	# Now let's plot our data
-	chart.y_labels_function = func(value: float): return str(int(value))
-
-	# Configure the x axis so that there is one tick every two hours. This has to
-	# be precise to ensure that no interpolation happens
-	cp.x_scale = x.size() - 1
-	chart.set_x_domain(0, x.size() - 1)
-	chart.x_labels_function = func(value: float) -> String:
-		return "%2d h" % round(value)
-
-	# Configure the y axis 
+	# Configure the y axis. We set the scale and domain in such
+	# that we get ticks only on integers, not on floats. 
+	# We also configure the label function to not print decimal places.
 	var y_max_value := 0
 	for i in range(0, 24):
 		if blackbird_spots[i] > y_max_value:
@@ -61,5 +53,7 @@ func _ready():
 	y_max_value += 2 if (y_max_value % 2) == 0 else 1
 	cp.y_scale = y_max_value / 2
 	chart.set_y_domain(0, y_max_value)
+	chart.y_labels_function = func(value: float): return str(int(value))
 
+	# Now let's plot our data
 	chart.plot([blackbird_function, nightingale_function], cp)

--- a/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
+++ b/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
@@ -54,22 +54,22 @@ var max_samples: int = 100
 
 ## Dictionary of colors for all of the Chart elements.
 var colors: Dictionary = {
-    frame = Color.WHITE_SMOKE,
-    background = Color.WHITE,
-    borders = Color.RED,
-    bounding_box = Color.BLACK,
-    grid = Color.GRAY,
-    ticks = Color.BLACK,
-    text = Color.BLACK,
-    origin = Color.DIM_GRAY
+	frame = Color.WHITE_SMOKE,
+	background = Color.WHITE,
+	borders = Color.RED,
+	bounding_box = Color.BLACK,
+	grid = Color.GRAY,
+	ticks = Color.BLACK,
+	text = Color.BLACK,
+	origin = Color.DIM_GRAY
 }
 
 var font: FontFile = load("res://addons/easy_charts/utilities/assets/OpenSans-VariableFont_wdth,wght.ttf")
 var font_size: int = 13
 
 func _init() -> void:
-    ThemeDB.set_fallback_font(font)
-    ThemeDB.set_fallback_font_size(font_size)
+	ThemeDB.set_fallback_font(font)
+	ThemeDB.set_fallback_font_size(font_size)
 
 func get_string_size(text: String) -> Vector2:
-    return font.get_string_size(text)
+	return font.get_string_size(text)

--- a/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
+++ b/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
@@ -34,8 +34,8 @@ func _draw() -> void:
 		_draw_background()
 	
 	if get_parent().chart_properties.draw_grid_box:
-		_draw_vertical_grid()
-		_draw_horizontal_grid()
+		_draw_x_ticks()
+		_draw_y_ticks()
 	
 	if get_parent().chart_properties.draw_origin:
 		_draw_origin()
@@ -63,114 +63,104 @@ func _draw_origin() -> void:
 		)
 
 
-func _draw_vertical_grid() -> void:
-	# draw vertical lines
-	
-	# 1. the amount of lines is equals to the X_scale: it identifies in how many sectors the x domain
-	#    should be devided
-	# 2. calculate the spacing between each line in pixel. It is equals to x_sampled_domain / x_scale
-	# 3. calculate the offset in the real x domain, which is x_domain / x_scale.
-	var scaler: int = get_parent().chart_properties.x_scale
-	var x_pixel_dist: float = self.plot_box.size.x / scaler
+func _draw_x_ticks() -> void:
+	var labels = x_domain.get_tick_labels()
+	var tick_count = labels.size()
+
+	var x_pixel_dist: float = self.plot_box.size.x / tick_count
 	
 	var vertical_grid: PackedVector2Array = []
 	var vertical_ticks: PackedVector2Array = []
 	
-	for _x in (scaler + 1):
-		var x_sampled_val: float = (_x * x_pixel_dist) + self.plot_box.position.x
-		var x_val: float = ECUtilities._map_domain(x_sampled_val, ChartAxisDomain.from_bounds(self.plot_box.position.x, self.plot_box.end.x), x_domain)
+	for i in range(tick_count):
+		var x_position: float = (i * x_pixel_dist) + self.plot_box.position.x
 
-		var top: Vector2 = Vector2(x_sampled_val, self.box.position.y)
-		var bottom: Vector2 = Vector2(x_sampled_val, self.box.end.y)
-		
+		var top: Vector2 = Vector2(x_position, self.box.position.y)
+		var bottom: Vector2 = Vector2(x_position, self.box.end.y)
+
 		vertical_grid.append(top)
 		vertical_grid.append(bottom)
-		
+
 		vertical_ticks.append(bottom)
 		vertical_ticks.append(bottom + Vector2(0, get_parent().chart_properties.x_tick_size))
-		
-		# Draw V Tick Labels
+
+		# Draw x tick labels
 		if get_parent().chart_properties.show_tick_labels:
-			var tick_lbl: String = _get_tick_label(_x, x_val, x_domain.has_decimals, self.x_labels_function)
+			var label: String = labels[i]
 			draw_string(
 				get_parent().chart_properties.font, 
-				_get_vertical_tick_label_pos(bottom, tick_lbl),
-				tick_lbl,HORIZONTAL_ALIGNMENT_CENTER, -1, ThemeDB.fallback_font_size,
-				get_parent().chart_properties.colors.text, TextServer.JUSTIFICATION_NONE, TextServer.DIRECTION_AUTO,
+				_get_x_tick_label_position(bottom, label),
+				label,
+				HORIZONTAL_ALIGNMENT_CENTER,
+				-1,
+				ThemeDB.fallback_font_size,
+				get_parent().chart_properties.colors.text,
+				TextServer.JUSTIFICATION_NONE,
+				TextServer.DIRECTION_AUTO,
 				TextServer.ORIENTATION_HORIZONTAL
 			)
-	
-	# Draw V Grid
+
+	# Draw x grid
 	if get_parent().chart_properties.draw_vertical_grid:
 		draw_multiline(vertical_grid, get_parent().chart_properties.colors.grid, 1)
-	
-	# Draw V Ticks
+
+	# Draw x ticks
 	if get_parent().chart_properties.draw_ticks:
 		draw_multiline(vertical_ticks, get_parent().chart_properties.colors.ticks, 1)
 
-
-func _draw_horizontal_grid() -> void:
-	# 1. the amount of lines is equals to the y_scale: it identifies in how many sectors the y domain
-	#    should be devided
-	# 2. calculate the spacing between each line in pixel. It is equals to y_sampled_domain / y_scale
-	# 3. calculate the offset in the real y domain, which is y_domain / y_scale.
-	var scaler: int = get_parent().chart_properties.y_scale
-	var y_pixel_dist: float = self.plot_box.size.y / scaler
+func _draw_y_ticks() -> void:
+	var labels = y_domain.get_tick_labels()
+	var tick_count = labels.size()
+	var y_pixel_dist: float = self.plot_box.size.y / tick_count
 	
 	var horizontal_grid: PackedVector2Array = []
 	var horizontal_ticks: PackedVector2Array = []
 	
-	for _y in (scaler + 1):
-		var y_sampled_val: float = (_y * y_pixel_dist) + self.plot_box.position.y
-		var y_val: float = ECUtilities._map_domain(y_sampled_val, ChartAxisDomain.from_bounds(self.plot_box.end.y, self.plot_box.position.y), y_domain)
+	for i in range(tick_count):
+		var y_sampled_val: float = self.plot_box.size.y - (i * y_pixel_dist) + self.plot_box.position.y
 
 		var left: Vector2 = Vector2(self.box.position.x, y_sampled_val)
 		var right: Vector2 = Vector2(self.box.end.x, y_sampled_val)
-		
+
 		horizontal_grid.append(left)
 		horizontal_grid.append(right)
-		
+
 		horizontal_ticks.append(left)
 		horizontal_ticks.append(left - Vector2(get_parent().chart_properties.y_tick_size, 0))
-		
-		# Draw H Tick Labels
+
+		# Draw y tick labels
 		if get_parent().chart_properties.show_tick_labels:
-			var tick_lbl: String = _get_tick_label(_y, y_val, y_domain.has_decimals, y_labels_function)
+			var label: String = labels[i]
 			draw_string(
-				get_parent().chart_properties.font, 
-				_get_horizontal_tick_label_pos(left, tick_lbl),
-				tick_lbl,
+				get_parent().chart_properties.font,
+				_get_y_tick_label_position(left, label),
+				label,
 				HORIZONTAL_ALIGNMENT_CENTER,
-				-1, ThemeDB.fallback_font_size,
+				-1,
+				ThemeDB.fallback_font_size,
 				get_parent().chart_properties.colors.text,
-				TextServer.JUSTIFICATION_NONE, TextServer.DIRECTION_AUTO, TextServer.ORIENTATION_HORIZONTAL
+				TextServer.JUSTIFICATION_NONE,
+				TextServer.DIRECTION_AUTO,
+				TextServer.ORIENTATION_HORIZONTAL
 			)
 	
-	# Draw H Grid
+	# Draw y grid
 	if get_parent().chart_properties.draw_horizontal_grid:
 		draw_multiline(horizontal_grid, get_parent().chart_properties.colors.grid, 1)
 	
-	# Draw H Ticks
+	# Draw y ticks
 	if get_parent().chart_properties.draw_ticks:
 		draw_multiline(horizontal_ticks, get_parent().chart_properties.colors.ticks, 1)
 		
 
-func _get_vertical_tick_label_pos(base_position: Vector2, text: String) -> Vector2:
+func _get_x_tick_label_position(base_position: Vector2, text: String) -> Vector2:
 	return  base_position + Vector2(
 		- get_parent().chart_properties.font.get_string_size(text).x / 2,
 		ThemeDB.fallback_font_size + get_parent().chart_properties.x_tick_size
 	)
 
-func _get_horizontal_tick_label_pos(base_position: Vector2, text: String) -> Vector2:
+func _get_y_tick_label_position(base_position: Vector2, text: String) -> Vector2:
 	return base_position - Vector2(
 		get_parent().chart_properties.font.get_string_size(text).x + get_parent().chart_properties.y_tick_size + get_parent().chart_properties.x_ticklabel_space, 
 		- ThemeDB.fallback_font_size * 0.35
 	)
-
-func _get_tick_label(line_index: int, line_value: float, axis_has_decimals: bool, labels_function: Callable) -> String:
-	var tick_lbl: String = ""
-	if labels_function.is_null():
-		tick_lbl = ECUtilities._format_value(line_value, axis_has_decimals)
-	else:
-		tick_lbl = labels_function.call(line_value)
-	return tick_lbl

--- a/addons/easy_charts/utilities/containers/canvas/plot_box/plot_box.gd
+++ b/addons/easy_charts/utilities/containers/canvas/plot_box/plot_box.gd
@@ -1,56 +1,32 @@
 extends Control
 class_name PlotBox
 
-signal function_point_entered(point, function)
-signal function_point_exited(point, function)
-@onready var tooltip: DataTooltip = $Tooltip
+# TODO: These signals have been removed. If anyone needs them, we can bring
+# them back, but from the Chart, not from the PlotBox.
+#signal function_point_entered(point, function)
+#signal function_point_exited(point, function)
 
 var focused_point: Point
 var focused_function: Function
 
-var x_labels_function: Callable = Callable()
-var y_labels_function: Callable = Callable()
-
 var box_margins: Vector2 # Margins relative to this rect, in order to make space for ticks and tick_labels
 var plot_inner_offset: Vector2 = Vector2(15, 15) # How many pixels from the broders should the plot be
 
+# TODO: Remove
 var chart_properties: ChartProperties
 
-func set_labels_functions(x_labels_function: Callable, y_labels_function: Callable) -> void:
-    self.x_labels_function = x_labels_function
-    self.y_labels_function = y_labels_function
-
 func get_box() -> Rect2:
-    var box: Rect2 = get_rect()
-    box.position.x += box_margins.x
+	var box: Rect2 = get_rect()
+	box.position.x += box_margins.x
 #	box.position.y += box_margins.y
-    box.end.x -= box_margins.x
-    box.end.y -= box_margins.y
-    return box
+	box.end.x -= box_margins.x
+	box.end.y -= box_margins.y
+	return box
 
 func get_plot_box() -> Rect2:
-    var inner_box: Rect2 = get_box()
-    inner_box.position.x += plot_inner_offset.x
-    inner_box.position.y += plot_inner_offset.y
-    inner_box.end.x -= plot_inner_offset.x * 2
-    inner_box.end.y -= plot_inner_offset.y * 2
-    return inner_box
-
-func _on_point_entered(point: Point, function: Function, props: Dictionary = {}) -> void:
-    self.focused_function = function
-    var x_value: String = x_labels_function.call(point.value.x) if not x_labels_function.is_null() else \
-        point.value.x if point.value.x is String else ECUtilities._format_value(point.value.x, ECUtilities._is_decimal(point.value.x))
-    var y_value: String = y_labels_function.call(point.value.y) if not y_labels_function.is_null() else \
-        point.value.y if point.value.y is String else ECUtilities._format_value(point.value.y, ECUtilities._is_decimal(point.value.y))
-    var color: Color = function.get_color() if function.get_type() != Function.Type.PIE \
-        else function.get_gradient().sample(props.interpolation_index)
-    tooltip.show()
-    tooltip.update_values(x_value, y_value, function.name, color)
-    tooltip.update_position(point.position)
-    emit_signal("function_point_entered", point, function)
-
-func _on_point_exited(point: Point, function: Function) -> void:
-    if function != self.focused_function:
-        return
-    tooltip.hide()
-    emit_signal("function_point_exited", point, function)
+	var inner_box: Rect2 = get_box()
+	inner_box.position.x += plot_inner_offset.x
+	inner_box.position.y += plot_inner_offset.y
+	inner_box.end.x -= plot_inner_offset.x * 2
+	inner_box.end.y -= plot_inner_offset.y * 2
+	return inner_box


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR changes how labels are generate for discrete (== string-based) domains. In that case, the function's x-values will be used for tick labels as well as inside tooltips.

To make this work for tooltips, the tooltip handling was moved form `PlotBox`  to `Chart`, because `PlotBox` did not have a reference to the `ChartAxisDomain`s and passing the domains to the `PlotBox` seemed unfeasible.

To precisely place the labels on ticks, the `x_scale` and `y_scale` `ChartProperties` are ignored.

It was also necessary to put more label and value mapping logic into `ChartAxisDomain`. From my perspective, this makes sense, since basically the domain knows how values have to be interpolated and how to generate tick labels and value labels correctly. Previously, this logic was scattered across `FunctionPlotter` sub-classes (including duplicated code), the `PlotBox` and the `GridBox` classes.

## What is the current behavior?

At the moment, charts use the index values as labels and they might apply interpolation based on the axis scale.

## What is the new behavior?

Now, the x-value strings are used as labels.

## Additional context

This PR was split from #121. However, I found some more changes required, to make the solution universally applicable for all chart types.
