### PR TITLE
Add bounds checks to Line and Scatter Plotters

### DIFF
--- a/addons/easy_charts/control_charts/plotters/area_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/area_plotter.gd
@@ -21,8 +21,6 @@ func _draw_areas() -> void:
 			fp_augmented = _get_spline_points()
 		Function.Interpolation.NONE, _:
 			return
-	if fp_augmented.size() == 0:
-		return
 
 	fp_augmented.push_back(Vector2(fp_augmented[-1].x, box.end.y + 80))
 	fp_augmented.push_back(Vector2(fp_augmented[0].x, box.end.y + 80))
@@ -48,4 +46,10 @@ func _draw_areas() -> void:
 
 func _draw() -> void:
 	super._draw()
+
+	#prevent error when drawing with no data.
+	if points_positions.size() < 2:
+		printerr("Cannot plot a line with less than two points!")
+		return
+
 	_draw_areas()

--- a/addons/easy_charts/control_charts/plotters/area_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/area_plotter.gd
@@ -49,7 +49,7 @@ func _draw() -> void:
 
 	#prevent error when drawing with no data.
 	if points_positions.size() < 2:
-		printerr("Cannot plot a line with less than two points!")
+		printerr("Cannot plot an area with less than two points!")
 		return
 
 	_draw_areas()

--- a/addons/easy_charts/control_charts/plotters/area_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/area_plotter.gd
@@ -4,46 +4,48 @@ class_name AreaPlotter
 var base_color: Color = Color.WHITE
 
 func _init(function: Function) -> void:
-    super(function)
-    
-    self.base_color = function.get_color()
-    pass
+	super(function)
+
+	self.base_color = function.get_color()
+	pass
 
 func _draw_areas() -> void:
-    var box: Rect2 = get_box()
-    var fp_augmented: PackedVector2Array = []
-    match function.get_interpolation():
-        Function.Interpolation.LINEAR:
-            fp_augmented = points_positions
-        Function.Interpolation.STAIR:
-            fp_augmented = _get_stair_points()
-        Function.Interpolation.SPLINE:
-            fp_augmented = _get_spline_points()
-        Function.Interpolation.NONE, _:
-            return
-    
-    fp_augmented.push_back(Vector2(fp_augmented[-1].x, box.end.y + 80))
-    fp_augmented.push_back(Vector2(fp_augmented[0].x, box.end.y + 80))
-    
-    # Precompute the scaling factor for the remap.
-    var end_y = box.end.y
-    var pos_y = box.position.y
-    var scale = 0.5 / (pos_y - end_y)
-    
-    # Pre-allocate the PackedColorArray based on the number of points.
-    var point_count = fp_augmented.size()
-    var colors = PackedColorArray()
-    colors.resize(point_count)
-    
-    # Compute alpha for each point and assign the color.
-    for i in range(point_count):
-        var point: Vector2 = fp_augmented[i]
-        var alpha: float = (point.y - end_y) * scale
-        colors[i] = Color(base_color, alpha)
-    
-    # Draw the polygon with the computed colors.
-    draw_polygon(fp_augmented, colors)
+	var box: Rect2 = get_box()
+	var fp_augmented: PackedVector2Array = []
+	match function.get_interpolation():
+		Function.Interpolation.LINEAR:
+			fp_augmented = points_positions
+		Function.Interpolation.STAIR:
+			fp_augmented = _get_stair_points()
+		Function.Interpolation.SPLINE:
+			fp_augmented = _get_spline_points()
+		Function.Interpolation.NONE, _:
+			return
+	if fp_augmented.size() == 0:
+		return
+
+	fp_augmented.push_back(Vector2(fp_augmented[-1].x, box.end.y + 80))
+	fp_augmented.push_back(Vector2(fp_augmented[0].x, box.end.y + 80))
+	
+	# Precompute the scaling factor for the remap.
+	var end_y = box.end.y
+	var pos_y = box.position.y
+	var scale = 0.5 / (pos_y - end_y)
+	
+	# Pre-allocate the PackedColorArray based on the number of points.
+	var point_count = fp_augmented.size()
+	var colors = PackedColorArray()
+	colors.resize(point_count)
+	
+	# Compute alpha for each point and assign the color.
+	for i in range(point_count):
+		var point: Vector2 = fp_augmented[i]
+		var alpha: float = (point.y - end_y) * scale
+		colors[i] = Color(base_color, alpha)
+	
+	# Draw the polygon with the computed colors.
+	draw_polygon(fp_augmented, colors)
 
 func _draw() -> void:
-    super._draw()
-    _draw_areas()
+	super._draw()
+	_draw_areas()

--- a/addons/easy_charts/control_charts/plotters/line_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/line_plotter.gd
@@ -1,26 +1,23 @@
 extends ScatterPlotter
 class_name LinePlotter
 
-func _init(function: Function) -> void:
-	super(function)
-
 func _get_spline_points(density: float = 10.0, tension: float = 1) -> PackedVector2Array:
 	var spline_points: PackedVector2Array = []
 	
-	var augmented: PackedVector2Array = points_positions
-	var pi: Vector2 = augmented[0] - Vector2(10, -10)
-	var pf: Vector2 = augmented[augmented.size() - 1] + Vector2(10, 10)
+	var augmented_positions: PackedVector2Array = points_positions
+	var pi: Vector2 = augmented_positions[0] - Vector2(10, -10)
+	var pf: Vector2 = augmented_positions[augmented_positions.size() - 1] + Vector2(10, 10)
 	
-	augmented.insert(0, pi)
-	augmented.push_back(pf)
+	augmented_positions.insert(0, pi)
+	augmented_positions.push_back(pf)
 	
-	for p in range(1, augmented.size() - 2, 1) : #(inclusive)
+	for p in range(1, augmented_positions.size() - 2, 1) : #(inclusive)
 		for f in range(0, density + 1, 1):
 			spline_points.append(
-				augmented[p].cubic_interpolate(
-					augmented[p + 1], 
-					augmented[p - 1], 
-					augmented[p + 2], 
+				augmented_positions[p].cubic_interpolate(
+					augmented_positions[p + 1], 
+					augmented_positions[p - 1], 
+					augmented_positions[p + 2], 
 					f / density)
 				)
 	

--- a/addons/easy_charts/control_charts/plotters/line_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/line_plotter.gd
@@ -35,7 +35,7 @@ func _get_stair_points() -> PackedVector2Array:
 
 func _draw() -> void:
 	super._draw()
-	
+
 	#prevent error when drawing with no data.
 	if points_positions.size() < 2:
 		printerr("Cannot plot a line with less than two points!")

--- a/addons/easy_charts/control_charts/plotters/pie_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/pie_plotter.gd
@@ -16,117 +16,113 @@ var slices_conc: Array[bool] = []
 
 var focused_point: Point
 
-func _init(function: Function) -> void:
-    super(function)
-    pass
-
 func _draw() -> void:
-    super._draw()
-    box = get_box()
-    radius = min(box.size.x, box.size.y) * 0.5 * radius_multiplayer
-    var total: float = get_total()
-    var ratios: PackedFloat32Array = get_ratios(total)
-    sample(radius, box.get_center(), total, ratios)
-    _draw_pie()
-    _draw_labels(radius, box.get_center(), ratios)
+	super._draw()
+	box = get_box()
+	radius = min(box.size.x, box.size.y) * 0.5 * radius_multiplayer
+	var total: float = get_total()
+	var ratios: PackedFloat32Array = get_ratios(total)
+	sample(radius, box.get_center(), total, ratios)
+	_draw_pie()
+	_draw_labels(radius, box.get_center(), ratios)
 
 func get_total() -> float:
-    # Calculate total and ratios
-    var total: float = 0.0
-    for value in function.__x:
-        total += float(value)
-    return total
+	# Calculate total and ratios
+	var total: float = 0.0
+	for value in function.__x:
+		total += float(value)
+	return total
 
 func get_ratios(total: float) -> PackedFloat32Array:
-    var ratios: PackedFloat32Array = []
-    for value in function.__x:
-        ratios.push_back(value / total * 100)
-    return ratios
+	var ratios: PackedFloat32Array = []
+	for value in function.__x:
+		ratios.push_back(value / total * 100)
+	return ratios
 
 func sample(radius: float, center: Vector2, total: float, ratios: PackedFloat32Array) -> void:
-    # Calculate directions
-    slices.clear()
-    slices_dirs = []
-    slices_conc = []
-    
-    var start_angle: float = 0.0
-    for ratio in ratios:
-        var end_angle: float = start_angle + (2 * PI * float(ratio) * 0.01)
-        slices.append(
-            _calc_circle_arc_poly(
-                center,
-                radius,
-                start_angle,
-                end_angle
-            )
-        )
-        slices_conc.append( abs(end_angle - start_angle) >= PI )
-        start_angle = end_angle
-    
-    for i in slices.size():
-        var slice = slices[i]
-        var mid_point: Vector2 = (slice[-1] + slice[1]) / 2
-        if (slices_conc[i]): mid_point = (2 * center) - mid_point
-        draw_circle(mid_point, 1, Color.RED)
-        slices_dirs.append(center.direction_to(mid_point))
+	# Calculate directions
+	slices.clear()
+	slices_dirs = []
+	slices_conc = []
+	
+	var start_angle: float = 0.0
+	for ratio in ratios:
+		var end_angle: float = start_angle + (2 * PI * float(ratio) * 0.01)
+		slices.append(
+			_calc_circle_arc_poly(
+				center,
+				radius,
+				start_angle,
+				end_angle
+			)
+		)
+		slices_conc.append( abs(end_angle - start_angle) >= PI )
+		start_angle = end_angle
+	
+	for i in slices.size():
+		var slice = slices[i]
+		var mid_point: Vector2 = (slice[-1] + slice[1]) / 2
+		if (slices_conc[i]): mid_point = (2 * center) - mid_point
+		draw_circle(mid_point, 1, Color.RED)
+		slices_dirs.append(center.direction_to(mid_point))
 
 func _calc_circle_arc_poly(center: Vector2, radius: float, angle_from: float, angle_to: float) -> PackedVector2Array:
-    var nb_points: int = 64
-    var points_arc: PackedVector2Array = PackedVector2Array()
-    points_arc.push_back(center)
-    
-    for i in range(nb_points + 1):
-        var angle_point: float = - (PI / 2) + angle_from + i * (angle_to - angle_from) / nb_points
-        points_arc.push_back(center + (Vector2.RIGHT.rotated(angle_point).normalized() * radius))
-    
-    return points_arc
+	var nb_points: int = 64
+	var points_arc: PackedVector2Array = PackedVector2Array()
+	points_arc.push_back(center)
+	
+	for i in range(nb_points + 1):
+		var angle_point: float = - (PI / 2) + angle_from + i * (angle_to - angle_from) / nb_points
+		points_arc.push_back(center + (Vector2.RIGHT.rotated(angle_point).normalized() * radius))
+	
+	return points_arc
 
 func _draw_pie() -> void:
-    for i in slices.size():
-        draw_colored_polygon(slices[i], function.get_gradient().sample(float(i) / float(slices.size() - 1)))
-        draw_polyline(slices[i], Color.WHITE, 2.0, true)
+	for i in slices.size():
+		draw_colored_polygon(slices[i], function.get_gradient().sample(float(i) / float(slices.size() - 1)))
+		draw_polyline(slices[i], Color.WHITE, 2.0, true)
 
 func _draw_labels(radius: float, center: Vector2, ratios: PackedFloat32Array) -> void:
-    for i in slices_dirs.size():
-        var ratio_lbl: String = "%.1f%%" % ratios[i]
-        var value_lbl: String = "(%s)" % function.__x[i]
-        var position: Vector2 = center + slices_dirs[i] * radius * 0.5
-        var ratio_lbl_size: Vector2 = get_chart_properties().get_string_size(ratio_lbl)
-        var value_lbl_size: Vector2 = get_chart_properties().get_string_size(value_lbl)
-        draw_string(
-            get_chart_properties().font,
-            position - Vector2(ratio_lbl_size.x / 2, 0),
-            ratio_lbl,
-            HORIZONTAL_ALIGNMENT_CENTER,
-            ratio_lbl_size.x,
-            16,
-            Color.WHITE,
-            3,
-            TextServer.DIRECTION_AUTO,
-            TextServer.ORIENTATION_HORIZONTAL
-        )
-        draw_string(
-            get_chart_properties().font,
-            position - Vector2(value_lbl_size.x / 2, - value_lbl_size.y),
-            value_lbl,
-            HORIZONTAL_ALIGNMENT_CENTER,
-            value_lbl_size.x,
-            16,
-            Color.WHITE,
-            3,TextServer.DIRECTION_AUTO,TextServer.ORIENTATION_HORIZONTAL
-        )
+	for i in slices_dirs.size():
+		var ratio_lbl: String = "%.1f%%" % ratios[i]
+		var value_lbl: String = "(%s)" % function.__x[i]
+		var position: Vector2 = center + slices_dirs[i] * radius * 0.5
+		var ratio_lbl_size: Vector2 = get_chart_properties().get_string_size(ratio_lbl)
+		var value_lbl_size: Vector2 = get_chart_properties().get_string_size(value_lbl)
+		draw_string(
+			get_chart_properties().font,
+			position - Vector2(ratio_lbl_size.x / 2, 0),
+			ratio_lbl,
+			HORIZONTAL_ALIGNMENT_CENTER,
+			ratio_lbl_size.x,
+			16,
+			Color.WHITE,
+			3,
+			TextServer.DIRECTION_AUTO,
+			TextServer.ORIENTATION_HORIZONTAL
+		)
+		draw_string(
+			get_chart_properties().font,
+			position - Vector2(value_lbl_size.x / 2, - value_lbl_size.y),
+			value_lbl,
+			HORIZONTAL_ALIGNMENT_CENTER,
+			value_lbl_size.x,
+			16,
+			Color.WHITE,
+			3,TextServer.DIRECTION_AUTO,TextServer.ORIENTATION_HORIZONTAL
+		)
 
 func _input(event: InputEvent) -> void:
-    if event is InputEventMouse:
-        for i in slices.size():
-            if Geometry2D.is_point_in_polygon(get_relative_position(event.position), slices[i]):
-                var point: Point = Point.new(self.box.get_center() + slices_dirs[i] * self.radius * 0.5, { x = function.__x[i], y = function.__y[i] })
-                if focused_point == point:
-                    return
-                else:
-                    focused_point = point
-                    emit_signal("point_entered", focused_point, function, { interpolation_index = float(i) / float(slices.size() - 1)})
-                    return
-        # Mouse is not in any slice's box
-        emit_signal("point_exited", focused_point, function)
-        focused_point = null
+	if event is InputEventMouse:
+		for i in slices.size():
+			if Geometry2D.is_point_in_polygon(get_relative_position(event.position), slices[i]):
+				var point: Point = Point.new(self.box.get_center() + slices_dirs[i] * self.radius * 0.5, { x = function.__x[i], y = function.__y[i] })
+				if focused_point == point:
+					return
+				else:
+					focused_point = point
+					emit_signal("point_entered", focused_point, function, { interpolation_index = float(i) / float(slices.size() - 1)})
+					return
+		# Mouse is not in any slice's box
+		emit_signal("point_exited", focused_point, function)
+		focused_point = null

--- a/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
@@ -42,7 +42,8 @@ func _sample() -> void:
 		)
 
 		var point = Point.new(_position, { x = function.__x[i], y = function.__y[i] })
-		# Don't generate outside y domain upper and lower bounds!
+
+		# Don't sample outside y domain upper and lower bounds
 		if point.position.y > y_sampled_domain.lb || point.position.y < y_sampled_domain.ub:
 			continue
 

--- a/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
@@ -4,78 +4,84 @@ class_name ScatterPlotter
 signal point_entered(point, function)
 signal point_exited(point, function)
 
-var points: Array[Point]
+var _points: Array[Point]
 var points_positions: PackedVector2Array
 var focused_point: Point
 
-var point_size: float
+var _point_size: float
 
-func _init(function: Function) -> void:
+func _init(function: Function):
 	super(function)
-	self.point_size = function.props.get("point_size", 3.0)
+	_point_size = function.props.get("point_size", 3.0)
 
 func _draw() -> void:
 	super._draw()
 	
+	_sample()
+
+	if function.get_marker() != Function.Marker.NONE:
+		for point_position in points_positions:
+			draw_function_point(point_position)
+
+func _sample() -> void:
 	var box: Rect2 = get_box()
 	var x_sampled_domain := ChartAxisDomain.from_bounds(box.position.x, box.end.x)
 	var y_sampled_domain := ChartAxisDomain.from_bounds(box.end.y, box.position.y)
-	sample(x_sampled_domain, y_sampled_domain)
-	
-	if function.get_marker() != Function.Marker.NONE:
-		for point in points:
-			# Don't plot points outside domain upper and lower bounds!
-			if point.position.y <= y_sampled_domain.lb and point.position.y >= y_sampled_domain.ub: 
-				draw_function_point(point.position)
 
-func sample(x_sampled_domain: ChartAxisDomain, y_sampled_domain: ChartAxisDomain) -> void:
-	points = []
+	_points = []
 	points_positions = []
-	var lower_bound: int = max(0, function.__x.size() - get_chart_properties().max_samples) \
-		if get_chart_properties().max_samples > 0 \
-		else 0
+	
+	var lower_bound: int = 0
+	if get_chart_properties().max_samples > 0:
+		lower_bound = max(0, function.__x.size() - get_chart_properties().max_samples)
 
 	for i in range(lower_bound, function.__x.size()):
 		var _position: Vector2 = Vector2(
 			ECUtilities._map_domain(float(function.__x[i]), x_domain, x_sampled_domain),
 			ECUtilities._map_domain(float(function.__y[i]), y_domain, y_sampled_domain)
 		)
-		points.push_back(Point.new(_position, { x = function.__x[i], y = function.__y[i] }))
+
+		var point = Point.new(_position, { x = function.__x[i], y = function.__y[i] })
+		# Don't generate outside y domain upper and lower bounds!
+		if point.position.y > y_sampled_domain.lb || point.position.y < y_sampled_domain.ub:
+			continue
+
+		_points.push_back(point)
 		points_positions.push_back(_position)
 
 func draw_function_point(point_position: Vector2) -> void:
 	match function.get_marker():
 		Function.Marker.SQUARE:
 			draw_rect(
-				Rect2(point_position - (Vector2.ONE * point_size), (Vector2.ONE * point_size * 2)), 
+				Rect2(point_position - (Vector2.ONE * _point_size), (Vector2.ONE * _point_size * 2)), 
 				function.get_color(), true, 1.0
 			)
 		Function.Marker.TRIANGLE:
 			draw_colored_polygon(
 				PackedVector2Array([
-					point_position + (Vector2.UP * point_size * 1.3),
-					point_position + (Vector2.ONE * point_size * 1.3),
-					point_position - (Vector2(1, -1) * point_size * 1.3)
+					point_position + (Vector2.UP * _point_size * 1.3),
+					point_position + (Vector2.ONE * _point_size * 1.3),
+					point_position - (Vector2(1, -1) * _point_size * 1.3)
 				]), function.get_color(), [], null
 			)
 		Function.Marker.CROSS:
 			draw_line(
-				point_position - (Vector2.ONE * point_size),
-				point_position + (Vector2.ONE * point_size),
-				function.get_color(), point_size, true
+				point_position - (Vector2.ONE * _point_size),
+				point_position + (Vector2.ONE * _point_size),
+				function.get_color(), _point_size, true
 			)
 			draw_line(
-				point_position + (Vector2(1, -1) * point_size),
-				point_position + (Vector2(-1, 1) * point_size),
-				function.get_color(), point_size / 2, true
+				point_position + (Vector2(1, -1) * _point_size),
+				point_position + (Vector2(-1, 1) * _point_size),
+				function.get_color(), _point_size / 2, true
 			)
 		Function.Marker.CIRCLE, _:
-			draw_circle(point_position, point_size, function.get_color())
+			draw_circle(point_position, _point_size, function.get_color())
 
 func _input(event: InputEvent) -> void:
 	if event is InputEventMouse:
-		for point in points:
-			if Geometry2D.is_point_in_circle(get_relative_position(event.position), point.position, self.point_size * 4):
+		for point in _points:
+			if Geometry2D.is_point_in_circle(get_relative_position(event.position), point.position, _point_size * 4):
 				if focused_point == point:
 					return
 				else:

--- a/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
+++ b/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
@@ -6,8 +6,9 @@ var x_label: String
 var y_label: String
 
 ## {n}_scale defines in how many sectors the grid will be divided.
-var x_scale: float = 5.0
-var y_scale: float = 2.0
+## This can only be used with non-discrete axes.
+var x_scale: float = 5
+var y_scale: float = 2
 
 var x_tick_size: float = 7
 var x_ticklabel_space: float = 5

--- a/addons/easy_charts/utilities/classes/plotting/function.gd
+++ b/addons/easy_charts/utilities/classes/plotting/function.gd
@@ -2,27 +2,27 @@ extends RefCounted
 class_name Function
 
 enum Type {
-    SCATTER,
-    LINE,
-    AREA,
-    PIE,
-    BAR
+	SCATTER,
+	LINE,
+	AREA,
+	PIE,
+	BAR
 }
 
 enum Interpolation {
-    NONE,
-    LINEAR,
-    STAIR,
-    SPLINE
+	NONE,
+	LINEAR,
+	STAIR,
+	SPLINE
 }
 
 # TODO: add new markers, like an empty circle, an empty box, etc.
 enum Marker {
-    NONE,
-    CIRCLE,
-    TRIANGLE,
-    SQUARE,
-    CROSS
+	NONE,
+	CIRCLE,
+	TRIANGLE,
+	SQUARE,
+	CROSS
 }
 
 var __x: Array
@@ -31,63 +31,63 @@ var name: String
 var props: Dictionary = {}
 
 func _init(x: Array, y: Array, name: String = "", props: Dictionary = {}) -> void:
-    self.__x = x.duplicate()
-    self.__y = y.duplicate()
-    self.name = name
-    if not props.is_empty() and props != null:
-        self.props = props
+	self.__x = x.duplicate()
+	self.__y = y.duplicate()
+	self.name = name
+	if not props.is_empty() and props != null:
+		self.props = props
 
 func get_point(index: int) -> Array:
-    return [self.__x[index], self.__y[index]]
+	return [self.__x[index], self.__y[index]]
 
 func add_point(x: float, y: float) -> void:
-    self.__x.append(x)
-    self.__y.append(y)
+	self.__x.append(x)
+	self.__y.append(y)
 
 func set_point(index: int, x: float, y: float) -> void:
-    self.__x[index] = x
-    self.__y[index] = y
+	self.__x[index] = x
+	self.__y[index] = y
 
 func remove_point(index: int) -> void:
-    self.__x.remove_at(index)
-    self.__y.remove_at(index)
+	self.__x.remove_at(index)
+	self.__y.remove_at(index)
 
 func pop_back_point() -> void:
-    self.__x.pop_back()
-    self.__y.pop_back()
+	self.__x.pop_back()
+	self.__y.pop_back()
 
 func pop_front_point() -> void:
-    self.__x.pop_front()
-    self.__y.pop_front()
+	self.__x.pop_front()
+	self.__y.pop_front()
 
 func count_points() -> int:
-    return self.__x.size()
+	return self.__x.size()
 
 func get_color() -> Color:
-    return props.get("color", Color.DARK_SLATE_GRAY)
+	return props.get("color", Color.DARK_SLATE_GRAY)
 
 func get_gradient() -> Gradient:
-    return props.get("gradient", Gradient.new())
+	return props.get("gradient", Gradient.new())
 
 func get_marker() -> int:
-    return props.get("marker", Marker.NONE)
+	return props.get("marker", Marker.NONE)
 
 func get_type() -> int:
-    return props.get("type", Type.SCATTER)
+	return props.get("type", Type.SCATTER)
 
 func get_interpolation() -> int:
-    return props.get("interpolation", Interpolation.LINEAR)
+	return props.get("interpolation", Interpolation.LINEAR)
 
 func get_line_width() -> float:
-    return props.get("line_width", 2.0)
+	return props.get("line_width", 2.0)
 
 func get_visibility() -> bool:
-    return props.get("visible", true)
+	return props.get("visible", true)
 
 func copy() -> Function:
-    return Function.new(
-        self.__x.duplicate(),
-        self.__y.duplicate(),
-        self.name,
-        self.props.duplicate(true)
-    )
+	return Function.new(
+		self.__x.duplicate(),
+		self.__y.duplicate(),
+		self.name,
+		self.props.duplicate(true)
+	)

--- a/addons/easy_charts/utilities/containers/data_tooltip/data_tooltip.gd
+++ b/addons/easy_charts/utilities/containers/data_tooltip/data_tooltip.gd
@@ -10,35 +10,30 @@ var gap: float = 15
 @onready var color_rect: Panel = $PointData/Value/Color
 
 func _ready():
-    hide()
-    update_size()
+	hide()
+	update_size()
 
 func update_position(position: Vector2) -> void:
-    if (position.x + gap + size.x) > get_parent().size.x:
-        self.position = position - Vector2(size.x + gap, (get_rect().size.y / 2))
-    else:
-        self.position = position + Vector2(15, - (get_rect().size.y / 2))
-
-#func _process(delta):
-#	if Engine.editor_hint:
-#		return
-#	rect_position = get_global_mouse_position() + Vector2(15, - (get_rect().size.y / 2))
+	if (position.x + gap + size.x) > get_parent().size.x:
+		self.position = position - Vector2(size.x + gap, (get_rect().size.y / 2))
+	else:
+		self.position = position + Vector2(15, - (get_rect().size.y / 2))
 
 func set_font(font: FontFile) -> void:
-    theme.set("default_font", font)
+	theme.set("default_font", font)
 
 func update_values(x: String, y: String, function_name: String, color: Color):
-    x_lbl.set_text(x)
-    y_lbl.set_text(y)
-    func_lbl.set_text(function_name)
-    color_rect.get("theme_override_styles/panel").set("bg_color", color)
+	x_lbl.set_text(x)
+	y_lbl.set_text(y)
+	func_lbl.set_text(function_name)
+	color_rect.get("theme_override_styles/panel").set("bg_color", color)
 
 func update_size():
-    x_lbl.set_text("")
-    y_lbl.set_text("")
-    func_lbl.set_text("")
-    size = Vector2.ZERO
+	x_lbl.set_text("")
+	y_lbl.set_text("")
+	func_lbl.set_text("")
+	size = Vector2.ZERO
 
 func _on_DataTooltip_visibility_changed():
-    if not visible:
-        update_size()
+	if not visible:
+		update_size()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Apart from some variable re-naming and some code cleanups, this PR adds following checks:

- `AreaPlotter`: Do not attempt to plot anything in case there is not enough data. This is in line with the pre-draw check that is done in `LinePlotter`.
- `ScatterPlotter`: Do not sample points that are out of y-axis domain bounds. This should not have any functional impact but avoids drawing some points that should not be visible.

## Additional context

This was split from #121.
