### PR TITLE
[Fix] Pie chart example uses strings for y-values

### DIFF
--- a/addons/easy_charts/examples/pie_chart/pie_chart_example.gd
+++ b/addons/easy_charts/examples/pie_chart/pie_chart_example.gd
@@ -52,14 +52,14 @@ func _ready():
 	set_process(false)
 
 
-var new_val: float = 4.5
+var new_val: int = 20
 
 func _process(delta: float):
 	# This function updates the values of a function and then updates the plot
-	new_val += 5
+	new_val += 10
 
 	# we can use the `Function.add_point(x, y)` method to update a function
-	f1.add_point(new_val, cos(new_val) * 20)
+	f1.add_point(new_val, "C++ %s" % new_val)
 	chart.queue_redraw() # This will force the Chart to be updated
 
 

--- a/addons/easy_charts/utilities/classes/plotting/function.gd
+++ b/addons/easy_charts/utilities/classes/plotting/function.gd
@@ -40,7 +40,7 @@ func _init(x: Array, y: Array, name: String = "", props: Dictionary = {}) -> voi
 func get_point(index: int) -> Array:
 	return [self.__x[index], self.__y[index]]
 
-func add_point(x: float, y: float) -> void:
+func add_point(x: float, y: Variant) -> void:
 	self.__x.append(x)
 	self.__y.append(y)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes #129.

## What is the current behavior?

Right now, the pie chart example uses float y-values when "real time data" generation is turned on. This breaks in combination with the new discrete string handling of `ChartAxisDomain`. 

## What is the new behavior?

To fix this, the example was updated to always use strings for y-values.

## Additional context

Question: Should we add additional validation to `Function`s? The pie chart function could then check if y-values are strings. We can also add this to the ChartAxisDomain to ensure that all values on the domain are of the same data type. This might also fix other user mistakes.
