### PR TITLE
[Fix]: issue #134 regarding discrete x values

### DIFF
--- a/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
@@ -37,8 +37,8 @@ func _sample() -> void:
 
 	for i in range(lower_bound, function.__x.size()):
 		var _position: Vector2 = Vector2(
-			ECUtilities._map_domain(float(function.__x[i]), x_domain, x_sampled_domain),
-			ECUtilities._map_domain(float(function.__y[i]), y_domain, y_sampled_domain)
+			x_domain.map_to(i, function.__x, x_sampled_domain),
+			y_domain.map_to(i, function.__y, y_sampled_domain)
 		)
 
 		var point = Point.new(_position, { x = function.__x[i], y = function.__y[i] })


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR fixes #134, it's a simple change and actually reuses an existing function introduced during the discrete feature PR #126. 


## What is the current behavior?

The problem was that the discrete string values were being casted to float to be used in the Godot `remap()` function. PR #126 actually already included the logic to map discrete values using their index, with the `map_to()` function inside `chart_axis_domain.gd`.
Therefore it was an easy fix, I am reusing the `map_to()` function now in `scatter_plotter.gd` which is also used in `bar_plotter.gd` so it actually makes things more consistent.

## What is the new behavior?
Tested the example from issue #134 and it is fixed, also did some other tests with random strings. Now any string should work perfectly fine. The other examples also shouldn't be affected.
![Capture](https://github.com/user-attachments/assets/d6aaa972-1c6c-4697-8779-9d160fd1e114)


