### PR TITLE
fix: Legend shows bar chart function colors

### DIFF
--- a/addons/easy_charts/utilities/containers/legend/function_label.tscn
+++ b/addons/easy_charts/utilities/containers/legend/function_label.tscn
@@ -4,21 +4,17 @@
 [ext_resource type="Script" uid="uid://ckinjw2oipoxc" path="res://addons/easy_charts/utilities/containers/legend/function_label.gd" id="2"]
 
 [node name="FunctionLabel" type="HBoxContainer"]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 theme_override_constants/separation = 5
 script = ExtResource("2")
 
 [node name="FunctionType" type="Label" parent="."]
-offset_top = 293.0
-offset_right = 20.0
-offset_bottom = 307.0
 custom_minimum_size = Vector2(20, 0)
+layout_mode = 2
 script = ExtResource("1")
 
 [node name="FunctionName" type="Label" parent="."]
-offset_left = 25.0
-offset_top = 293.0
-offset_right = 25.0
-offset_bottom = 307.0
+layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)

--- a/addons/easy_charts/utilities/containers/legend/function_legend.gd
+++ b/addons/easy_charts/utilities/containers/legend/function_legend.gd
@@ -6,18 +6,18 @@ class_name FunctionLegend
 var chart_properties: ChartProperties
 
 func _ready() -> void:
-    pass
+	pass
 
 func clear() -> void:
-    for label in get_children():
-        label.queue_free()
+	for label in get_children():
+		label.queue_free()
 
 func add_function(function: Function) -> void:
-    var f_label: FunctionLabel = f_label_scn.instantiate()
-    add_child(f_label)
-    f_label.init_label(function)
+	var f_label: FunctionLabel = f_label_scn.instantiate()
+	add_child(f_label)
+	f_label.init_label(function)
 
 func add_label(type: int, color: Color, marker: int, name: String) -> void:
-    var f_label: FunctionLabel = f_label_scn.instantiate()
-    add_child(f_label)
-    f_label.init_clabel(type, color, marker, name)
+	var f_label: FunctionLabel = f_label_scn.instantiate()
+	add_child(f_label)
+	f_label.init_clabel(type, color, marker, name)

--- a/addons/easy_charts/utilities/containers/legend/function_type.gd
+++ b/addons/easy_charts/utilities/containers/legend/function_type.gd
@@ -6,64 +6,76 @@ var marker: int
 var color: Color
 
 func _draw() -> void:
-    var center: Vector2 = get_rect().get_center()
-    
-    match self.type:
-        Function.Type.LINE:
-            draw_line(
-                Vector2(get_rect().position.x, center.y), 
-                Vector2(get_rect().end.x, center.y), 
-                color, 3
-            )
-        Function.Type.AREA:
-            var c2: Color = color
-            c2.a = 0.3
-            draw_rect(
-                Rect2(
-                    Vector2(get_rect().position.x, center.y), 
-                    Vector2(get_rect().end.x, get_rect().end.y / 2)
-                ),
-                c2, 3
-            )
-            draw_line(
-                Vector2(get_rect().position.x, center.y), 
-                Vector2(get_rect().end.x, center.y), 
-                color, 3
-            )
-        Function.Type.PIE:
-            draw_rect(
-                Rect2(center - (Vector2.ONE * 3), (Vector2.ONE * 3 * 2)), 
-                color, 1.0
-            )
-        Function.Type.SCATTER, _:
-            pass
-    
-    match self.marker:
-        Function.Marker.NONE:
-            pass
-        Function.Marker.SQUARE:
-            draw_rect(
-                Rect2(center - (Vector2.ONE * 3), (Vector2.ONE * 3 * 2)), 
-                color, 1.0
-            )
-        Function.Marker.TRIANGLE:
-            draw_colored_polygon(
-                PackedVector2Array([
-                    center + (Vector2.UP * 3 * 1.3),
-                    center + (Vector2.ONE * 3 * 1.3),
-                    center - (Vector2(1, -1) * 3 * 1.3)
-                ]), color, [], null
-            )
-        Function.Marker.CROSS:
-            draw_line(
-                center - (Vector2.ONE * 3),
-                center + (Vector2.ONE * 3),
-                color, 3, true
-            )
-            draw_line(
-                center + (Vector2(1, -1) * 3),
-                center + (Vector2(-1, 1) * 3),
-                color, 3 / 2, true
-            )
-        Function.Marker.CIRCLE, _:
-            draw_circle(center, 3, color)
+	var center: Vector2 = get_rect().get_center()
+
+	match self.type:
+		Function.Type.LINE:
+			draw_line(
+				Vector2(get_rect().position.x, center.y),
+				Vector2(get_rect().end.x, center.y),
+				color, 3
+			)
+		Function.Type.AREA:
+			var color_light: Color = color
+			color_light.a = 0.3
+			draw_rect(
+				Rect2(
+					Vector2(get_rect().position.x, center.y),
+					Vector2(get_rect().end.x, get_rect().end.y / 2)
+				),
+				color_light,
+				3
+			)
+			draw_line(
+				Vector2(get_rect().position.x, center.y),
+				Vector2(get_rect().end.x, center.y),
+				color,
+				3
+			)
+		Function.Type.PIE:
+			draw_rect(
+				Rect2(center - (Vector2.ONE * 3), (Vector2.ONE * 3 * 2)),
+				color,
+				1.0
+			)
+		Function.Type.BAR:
+			draw_rect(
+				Rect2(
+					Vector2(get_rect().position),
+					Vector2(get_rect().end.x, get_rect().end.y)
+				),
+				color,
+				3
+			)
+		Function.Type.SCATTER, _:
+			pass
+
+	match self.marker:
+		Function.Marker.NONE:
+			pass
+		Function.Marker.SQUARE:
+			draw_rect(
+				Rect2(center - (Vector2.ONE * 3), (Vector2.ONE * 3 * 2)),
+				color, 1.0
+			)
+		Function.Marker.TRIANGLE:
+			draw_colored_polygon(
+				PackedVector2Array([
+					center + (Vector2.UP * 3 * 1.3),
+					center + (Vector2.ONE * 3 * 1.3),
+					center - (Vector2(1, -1) * 3 * 1.3)
+				]), color, [], null
+			)
+		Function.Marker.CROSS:
+			draw_line(
+				center - (Vector2.ONE * 3),
+				center + (Vector2.ONE * 3),
+				color, 3, true
+			)
+			draw_line(
+				center + (Vector2(1, -1) * 3),
+				center + (Vector2(-1, 1) * 3),
+				color, 3 / 2, true
+			)
+		Function.Marker.CIRCLE, _:
+			draw_circle(center, 3, color)


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes the Legend to show colored squares for bar chart functions.

## What is the current behavior?

All functions have a visual representation int the Legend, except for bar functions.

## What is the new behavior?

Showing a colored rect for bar chars in the Legend.
