### PR TITLE
Allow to style charts via theming

### DIFF
--- a/addons/easy_charts/control_charts/chart.gd
+++ b/addons/easy_charts/control_charts/chart.gd
@@ -23,20 +23,14 @@ var y_domain: ChartAxisDomain = null
 
 var chart_properties: ChartProperties = null
 
-var _has_user_defined_theme: bool
-
 ###########
-
-func _ready() -> void:
-	_has_user_defined_theme = theme != null
 
 func plot(functions: Array[Function], properties: ChartProperties = ChartProperties.new()) -> void:
 	self.functions = functions
 	self.chart_properties = properties
 
 	# If user does not set a theme, generate a Theme from chart properties.
-	if !_has_user_defined_theme:
-		theme = chart_properties.to_theme()
+	theme = _get_theme_from_properties(chart_properties)
 
 	_canvas.prepare_canvas(self.chart_properties)
 	plot_box.chart_properties = self.chart_properties
@@ -198,3 +192,36 @@ func _hide_tooltip(point: Point, function: Function) -> void:
 func _on_function_legend_function_clicked(function: Function) -> void:
 	function.toggle_visibility()
 	queue_redraw()
+
+func _get_theme_from_properties(chart_properties: ChartProperties) -> Theme:
+	var theme = Theme.new()
+	theme.default_font = chart_properties.font
+	
+	if !has_theme_color("origin_color", "Chart"):
+		theme.set_color("origin_color", "Chart", chart_properties.colors.origin)
+
+	if !has_theme_color("text_color", "Chart"):
+		theme.set_color("text_color", "Chart", chart_properties.colors.text)
+
+	if !has_theme_color("tick_color", "Chart"):
+		theme.set_color("tick_color", "Chart", chart_properties.colors.ticks)
+
+	if !has_theme_color("tick_grid_line_color", "Chart"):
+		theme.set_color("tick_grid_line_color", "Chart", chart_properties.colors.grid)
+
+	if !has_theme_stylebox("chart_area", "Chart"):
+		var chart_area := StyleBoxFlat.new()
+		chart_area.bg_color = chart_properties.colors.frame
+		chart_area.draw_center = chart_properties.draw_frame
+		chart_area.set_content_margin_all(15)
+		theme.set_stylebox("chart_area", "Chart", chart_area)
+
+	if !has_theme_stylebox("plot_area", "Chart"):
+		var plot_area := StyleBoxFlat.new()
+		plot_area.bg_color = chart_properties.colors.background
+		plot_area.draw_center = chart_properties.draw_background
+		plot_area.border_color = chart_properties.colors.bounding_box
+		plot_area.set_border_width_all(1 if chart_properties.draw_bounding_box else 0)
+		theme.set_stylebox("plot_area", "Chart", plot_area)
+
+	return theme

--- a/addons/easy_charts/control_charts/chart.gd
+++ b/addons/easy_charts/control_charts/chart.gd
@@ -23,17 +23,21 @@ var y_domain: ChartAxisDomain = null
 
 var chart_properties: ChartProperties = null
 
+var _has_user_defined_theme: bool
+
 ###########
 
 func _ready() -> void:
-	if theme == null:
-		theme = Theme.new()
+	_has_user_defined_theme = theme != null
 
 func plot(functions: Array[Function], properties: ChartProperties = ChartProperties.new()) -> void:
 	self.functions = functions
 	self.chart_properties = properties
 
-	theme.set("default_font", self.chart_properties.font)
+	# If user does not set a theme, generate a Theme from chart properties.
+	if !_has_user_defined_theme:
+		theme = chart_properties.to_theme()
+
 	_canvas.prepare_canvas(self.chart_properties)
 	plot_box.chart_properties = self.chart_properties
 	function_legend.chart_properties = self.chart_properties

--- a/addons/easy_charts/control_charts/chart.tscn
+++ b/addons/easy_charts/control_charts/chart.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://dlwq4kmdb3bhs"]
+[gd_scene load_steps=9 format=3 uid="uid://dlwq4kmdb3bhs"]
 
 [ext_resource type="Script" uid="uid://bn7n1q5r4n3jn" path="res://addons/easy_charts/control_charts/chart.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://dmesmjhiuqdo4" path="res://addons/easy_charts/utilities/containers/data_tooltip/data_tooltip.tscn" id="2"]
@@ -6,8 +6,6 @@
 [ext_resource type="Script" uid="uid://8xd8yvw7lumm" path="res://addons/easy_charts/utilities/containers/canvas/plot_box/plot_box.gd" id="4"]
 [ext_resource type="Script" uid="uid://doelssxa0y7ap" path="res://addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd" id="5"]
 [ext_resource type="PackedScene" uid="uid://c6ffuulowjw4g" path="res://addons/easy_charts/utilities/containers/legend/function_legend.tscn" id="6"]
-
-[sub_resource type="Theme" id="4"]
 
 [sub_resource type="StyleBoxEmpty" id="8"]
 
@@ -25,7 +23,6 @@ anchor_bottom = 1.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 mouse_filter = 1
-theme = SubResource("4")
 theme_override_styles/panel = SubResource("8")
 script = ExtResource("1")
 

--- a/addons/easy_charts/control_charts/chart.tscn
+++ b/addons/easy_charts/control_charts/chart.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://dlwq4kmdb3bhs"]
+[gd_scene load_steps=8 format=3 uid="uid://dlwq4kmdb3bhs"]
 
 [ext_resource type="Script" uid="uid://bn7n1q5r4n3jn" path="res://addons/easy_charts/control_charts/chart.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://dmesmjhiuqdo4" path="res://addons/easy_charts/utilities/containers/data_tooltip/data_tooltip.tscn" id="2"]
@@ -8,13 +8,6 @@
 [ext_resource type="PackedScene" uid="uid://c6ffuulowjw4g" path="res://addons/easy_charts/utilities/containers/legend/function_legend.tscn" id="6"]
 
 [sub_resource type="StyleBoxEmpty" id="8"]
-
-[sub_resource type="StyleBoxFlat" id="5"]
-content_margin_left = 15.0
-content_margin_top = 15.0
-content_margin_right = 15.0
-content_margin_bottom = 15.0
-draw_center = false
 
 [node name="Chart" type="PanelContainer"]
 anchors_preset = 15
@@ -31,7 +24,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 mouse_filter = 1
-theme_override_styles/panel = SubResource("5")
 script = ExtResource("3")
 
 [node name="CanvasContainer" type="VBoxContainer" parent="Canvas"]

--- a/addons/easy_charts/control_charts/dark_chart_theme.tres
+++ b/addons/easy_charts/control_charts/dark_chart_theme.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Theme" load_steps=3 format=3 uid="uid://dtt7rfw0ictfw"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rmy2u"]
+content_margin_left = 15.0
+content_margin_top = 15.0
+content_margin_right = 15.0
+content_margin_bottom = 15.0
+bg_color = Color(0.0862745, 0.101961, 0.113725, 1)
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_411bv"]
+
+[resource]
+Chart/base_type = &"Chart"
+Chart/colors/origin_color = Color(0.411765, 0.411765, 0.411765, 1)
+Chart/colors/text_color = Color(0.960784, 0.960784, 0.960784, 1)
+Chart/colors/tick_color = Color(0.156863, 0.203922, 0.258824, 1)
+Chart/colors/tick_grid_line_color = Color(0.156863, 0.203922, 0.258824, 1)
+Chart/styles/chart_area = SubResource("StyleBoxFlat_rmy2u")
+Chart/styles/plot_area = SubResource("StyleBoxEmpty_411bv")

--- a/addons/easy_charts/control_charts/default_chart_theme.tres
+++ b/addons/easy_charts/control_charts/default_chart_theme.tres
@@ -1,4 +1,6 @@
 [gd_resource type="Theme" format=3 uid="uid://dbgw3bjtopyhv"]
 
 [resource]
+Chart/colors/tick_color = Color(0, 0, 0, 1)
+Chart/colors/tick_grid_line_color = Color(0.745098, 0.745098, 0.745098, 1)
 Chart/colors/tick_label_color = Color(0, 0, 0, 1)

--- a/addons/easy_charts/control_charts/default_chart_theme.tres
+++ b/addons/easy_charts/control_charts/default_chart_theme.tres
@@ -1,6 +1,16 @@
-[gd_resource type="Theme" format=3 uid="uid://dbgw3bjtopyhv"]
+[gd_resource type="Theme" load_steps=2 format=3 uid="uid://dbgw3bjtopyhv"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_34bsk"]
+bg_color = Color(1, 1, 1, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0, 0, 0, 1)
 
 [resource]
+Chart/colors/origin_color = Color(0.411765, 0.411765, 0.411765, 1)
 Chart/colors/tick_color = Color(0, 0, 0, 1)
 Chart/colors/tick_grid_line_color = Color(0.745098, 0.745098, 0.745098, 1)
 Chart/colors/tick_label_color = Color(0, 0, 0, 1)
+Chart/styles/plot_area = SubResource("StyleBoxFlat_34bsk")

--- a/addons/easy_charts/control_charts/default_chart_theme.tres
+++ b/addons/easy_charts/control_charts/default_chart_theme.tres
@@ -10,7 +10,7 @@ border_color = Color(0, 0, 0, 1)
 
 [resource]
 Chart/colors/origin_color = Color(0.411765, 0.411765, 0.411765, 1)
+Chart/colors/text_color = Color(0, 0, 0, 1)
 Chart/colors/tick_color = Color(0, 0, 0, 1)
 Chart/colors/tick_grid_line_color = Color(0.745098, 0.745098, 0.745098, 1)
-Chart/colors/tick_label_color = Color(0, 0, 0, 1)
 Chart/styles/plot_area = SubResource("StyleBoxFlat_34bsk")

--- a/addons/easy_charts/control_charts/default_chart_theme.tres
+++ b/addons/easy_charts/control_charts/default_chart_theme.tres
@@ -1,0 +1,4 @@
+[gd_resource type="Theme" format=3 uid="uid://dbgw3bjtopyhv"]
+
+[resource]
+Chart/colors/tick_label_color = Color(0, 0, 0, 1)

--- a/addons/easy_charts/control_charts/default_chart_theme.tres
+++ b/addons/easy_charts/control_charts/default_chart_theme.tres
@@ -1,4 +1,7 @@
-[gd_resource type="Theme" load_steps=2 format=3 uid="uid://dbgw3bjtopyhv"]
+[gd_resource type="Theme" load_steps=3 format=3 uid="uid://dwbt0h7cp3cg5"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rmy2u"]
+bg_color = Color(0.960784, 0.960784, 0.960784, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_34bsk"]
 bg_color = Color(1, 1, 1, 1)
@@ -13,4 +16,5 @@ Chart/colors/origin_color = Color(0.411765, 0.411765, 0.411765, 1)
 Chart/colors/text_color = Color(0, 0, 0, 1)
 Chart/colors/tick_color = Color(0, 0, 0, 1)
 Chart/colors/tick_grid_line_color = Color(0.745098, 0.745098, 0.745098, 1)
+Chart/styles/chart_area = SubResource("StyleBoxFlat_rmy2u")
 Chart/styles/plot_area = SubResource("StyleBoxFlat_34bsk")

--- a/addons/easy_charts/control_charts/default_chart_theme.tres
+++ b/addons/easy_charts/control_charts/default_chart_theme.tres
@@ -1,6 +1,10 @@
 [gd_resource type="Theme" load_steps=3 format=3 uid="uid://dwbt0h7cp3cg5"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rmy2u"]
+content_margin_left = 15.0
+content_margin_top = 15.0
+content_margin_right = 15.0
+content_margin_bottom = 15.0
 bg_color = Color(0.960784, 0.960784, 0.960784, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_34bsk"]

--- a/addons/easy_charts/examples/area_chart/area_chart_example.gd
+++ b/addons/easy_charts/examples/area_chart/area_chart_example.gd
@@ -16,12 +16,6 @@ func _ready():
 	# Let's customize the chart properties, which specify how the chart
 	# should look, plus some additional elements like labels, the scale, etc...
 	var cp: ChartProperties = ChartProperties.new()
-	cp.colors.frame = Color("#161a1d")
-	cp.colors.background = Color.TRANSPARENT
-	cp.colors.grid = Color("#283442")
-	cp.colors.ticks = Color("#283442")
-	cp.colors.text = Color.WHITE_SMOKE
-	cp.draw_bounding_box = false
 	cp.title = "Air Quality Monitoring"
 	cp.x_label = "Time"
 	cp.y_label = "Sensor values"

--- a/addons/easy_charts/examples/area_chart/area_chart_example.tscn
+++ b/addons/easy_charts/examples/area_chart/area_chart_example.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://c2ymglyg812ss"]
+[gd_scene load_steps=5 format=3 uid="uid://c2ymglyg812ss"]
 
 [ext_resource type="Script" uid="uid://bcaslhu2t7xr3" path="res://addons/easy_charts/examples/area_chart/area_chart_example.gd" id="1"]
+[ext_resource type="Theme" uid="uid://dtt7rfw0ictfw" path="res://addons/easy_charts/control_charts/dark_chart_theme.tres" id="1_odo6d"]
 [ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -11,13 +12,14 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control2" type="Control"]
+[node name="AreaChartExample" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_odo6d")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/area_chart/area_chart_example.tscn
+++ b/addons/easy_charts/examples/area_chart/area_chart_example.tscn
@@ -11,7 +11,7 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control" type="Control"]
+[node name="Control2" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/addons/easy_charts/examples/bar_chart/bar_chart_example.gd
+++ b/addons/easy_charts/examples/bar_chart/bar_chart_example.gd
@@ -13,7 +13,7 @@ func _ready():
 	
 	# Let's customize the chart properties, which specify how the chart
 	# should look, plus some additional elements like labels, the scale, etc...
-	cp = ChartProperties.new()
+	var cp = ChartProperties.new()
 	cp.y_scale = 10
 	cp.draw_origin = true
 	cp.draw_bounding_box = false

--- a/addons/easy_charts/examples/bar_chart/bar_chart_example.gd
+++ b/addons/easy_charts/examples/bar_chart/bar_chart_example.gd
@@ -13,12 +13,7 @@ func _ready():
 	
 	# Let's customize the chart properties, which specify how the chart
 	# should look, plus some additional elements like labels, the scale, etc...
-	var cp: ChartProperties = ChartProperties.new()
-	cp.colors.frame = Color("#161a1d")
-	cp.colors.background = Color.TRANSPARENT
-	cp.colors.grid = Color("#283442")
-	cp.colors.ticks = Color("#283442")
-	cp.colors.text = Color.WHITE_SMOKE
+	cp = ChartProperties.new()
 	cp.y_scale = 10
 	cp.draw_origin = true
 	cp.draw_bounding_box = false

--- a/addons/easy_charts/examples/bar_chart/bar_chart_example.tscn
+++ b/addons/easy_charts/examples/bar_chart/bar_chart_example.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://dn8rdqup8ldnw"]
 
 [ext_resource type="Script" uid="uid://b1ioy02qwjlpe" path="res://addons/easy_charts/examples/bar_chart/bar_chart_example.gd" id="1"]
-[ext_resource type="Theme" uid="uid://dbgw3bjtopyhv" path="res://addons/easy_charts/control_charts/default_chart_theme.tres" id="1_2ibwh"]
+[ext_resource type="Theme" uid="uid://dwbt0h7cp3cg5" path="res://addons/easy_charts/control_charts/default_chart_theme.tres" id="1_2ibwh"]
 [ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2"]
 
 [sub_resource type="StyleBoxFlat" id="1"]

--- a/addons/easy_charts/examples/bar_chart/bar_chart_example.tscn
+++ b/addons/easy_charts/examples/bar_chart/bar_chart_example.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://dn8rdqup8ldnw"]
 
 [ext_resource type="Script" uid="uid://b1ioy02qwjlpe" path="res://addons/easy_charts/examples/bar_chart/bar_chart_example.gd" id="1"]
-[ext_resource type="Theme" uid="uid://dwbt0h7cp3cg5" path="res://addons/easy_charts/control_charts/default_chart_theme.tres" id="1_2ibwh"]
+[ext_resource type="Theme" uid="uid://dtt7rfw0ictfw" path="res://addons/easy_charts/control_charts/dark_chart_theme.tres" id="1_2ibwh"]
 [ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -12,7 +12,7 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control2" type="Control"]
+[node name="BarChartExample" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/addons/easy_charts/examples/bar_chart/bar_chart_example.tscn
+++ b/addons/easy_charts/examples/bar_chart/bar_chart_example.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://dn8rdqup8ldnw"]
+[gd_scene load_steps=5 format=3 uid="uid://dn8rdqup8ldnw"]
 
 [ext_resource type="Script" uid="uid://b1ioy02qwjlpe" path="res://addons/easy_charts/examples/bar_chart/bar_chart_example.gd" id="1"]
+[ext_resource type="Theme" uid="uid://dbgw3bjtopyhv" path="res://addons/easy_charts/control_charts/default_chart_theme.tres" id="1_2ibwh"]
 [ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -18,6 +19,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_2ibwh")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/line_chart/line_chart_example.gd
+++ b/addons/easy_charts/examples/line_chart/line_chart_example.gd
@@ -16,12 +16,6 @@ func _ready():
 	# Let's customize the chart properties, which specify how the chart
 	# should look, plus some additional elements like labels, the scale, etc...
 	var cp: ChartProperties = ChartProperties.new()
-	cp.colors.frame = Color("#161a1d")
-	cp.colors.background = Color.TRANSPARENT
-	cp.colors.grid = Color("#283442")
-	cp.colors.ticks = Color("#283442")
-	cp.colors.text = Color.WHITE_SMOKE
-	cp.draw_bounding_box = false
 	cp.title = "Air Quality Monitoring"
 	cp.x_label = "Time"
 	cp.y_label = "Sensor values"

--- a/addons/easy_charts/examples/line_chart/line_chart_example.tscn
+++ b/addons/easy_charts/examples/line_chart/line_chart_example.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://chcj7up8k8pa8"]
+[gd_scene load_steps=5 format=3 uid="uid://chcj7up8k8pa8"]
 
 [ext_resource type="Script" uid="uid://xafq3pfkghx0" path="res://addons/easy_charts/examples/line_chart/line_chart_example.gd" id="1"]
+[ext_resource type="Theme" uid="uid://dtt7rfw0ictfw" path="res://addons/easy_charts/control_charts/dark_chart_theme.tres" id="1_yu76g"]
 [ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -11,13 +12,14 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control2" type="Control"]
+[node name="LineChartExample" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_yu76g")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/multiplot/multiplot_example.gd
+++ b/addons/easy_charts/examples/multiplot/multiplot_example.gd
@@ -20,12 +20,6 @@ func _ready():
 	# Let's customize the chart properties, which specify how the chart
 	# should look, plus some additional elements like labels, the scale, etc...
 	var cp: ChartProperties = ChartProperties.new()
-	cp.colors.frame = Color("#161a1d")
-	cp.colors.background = Color.TRANSPARENT
-	cp.colors.grid = Color("#283442")
-	cp.colors.ticks = Color("#283442")
-	cp.colors.text = Color.WHITE_SMOKE
-	cp.draw_bounding_box = false
 	cp.show_legend = true
 	cp.title = "Air Quality Monitoring"
 	cp.x_label = "Time"

--- a/addons/easy_charts/examples/multiplot/multiplot_example.tscn
+++ b/addons/easy_charts/examples/multiplot/multiplot_example.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://7v0v5lsl0kqe"]
+[gd_scene load_steps=5 format=3 uid="uid://7v0v5lsl0kqe"]
 
 [ext_resource type="Script" uid="uid://ouq5e3pbw5c1" path="res://addons/easy_charts/examples/multiplot/multiplot_example.gd" id="1"]
+[ext_resource type="Theme" uid="uid://dtt7rfw0ictfw" path="res://addons/easy_charts/control_charts/dark_chart_theme.tres" id="1_eb5nb"]
 [ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -11,13 +12,14 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control2" type="Control"]
+[node name="MultiPlotExample" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_eb5nb")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/pie_chart/pie_chart_example.gd
+++ b/addons/easy_charts/examples/pie_chart/pie_chart_example.gd
@@ -16,12 +16,6 @@ func _ready():
 	# Let's customize the chart properties, which specify how the chart
 	# should look, plus some additional elements like labels, the scale, etc...
 	var cp: ChartProperties = ChartProperties.new()
-	cp.colors.frame = Color("#161a1d")
-	cp.colors.background = Color.TRANSPARENT
-	cp.colors.grid = Color("#283442")
-	cp.colors.ticks = Color("#283442")
-	cp.colors.text = Color.WHITE_SMOKE
-	cp.draw_bounding_box = false
 	cp.title = "Users preferences on programming languages"
 	cp.draw_grid_box = false
 	cp.show_legend = true

--- a/addons/easy_charts/examples/pie_chart/pie_chart_example.tscn
+++ b/addons/easy_charts/examples/pie_chart/pie_chart_example.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://be3nkm3rmqe7m"]
+[gd_scene load_steps=5 format=3 uid="uid://be3nkm3rmqe7m"]
 
 [ext_resource type="Script" uid="uid://btfgl143uq8jc" path="res://addons/easy_charts/examples/pie_chart/pie_chart_example.gd" id="1"]
+[ext_resource type="Theme" uid="uid://dtt7rfw0ictfw" path="res://addons/easy_charts/control_charts/dark_chart_theme.tres" id="1_pwysg"]
 [ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -11,13 +12,14 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control2" type="Control"]
+[node name="PieChartExample" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_pwysg")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/scatter_chart/scatter_chart_example.gd
+++ b/addons/easy_charts/examples/scatter_chart/scatter_chart_example.gd
@@ -18,12 +18,6 @@ func _ready():
 	# Let's customize the chart properties, which specify how the chart
 	# should look, plus some additional elements like labels, the scale, etc...
 	var cp: ChartProperties = ChartProperties.new()
-	cp.colors.frame = Color("#161a1d")
-	cp.colors.background = Color.TRANSPARENT
-	cp.colors.grid = Color("#283442")
-	cp.colors.ticks = Color("#283442")
-	cp.colors.text = Color.WHITE_SMOKE
-	cp.draw_bounding_box = false
 	cp.title = "Air Quality Monitoring"
 	cp.x_label = "Time"
 	cp.y_label = "Sensor values"

--- a/addons/easy_charts/examples/scatter_chart/scatter_chart_example.tscn
+++ b/addons/easy_charts/examples/scatter_chart/scatter_chart_example.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://cekkstadxpimf"]
+[gd_scene load_steps=5 format=3 uid="uid://cekkstadxpimf"]
 
 [ext_resource type="Script" uid="uid://drjv3jppfmods" path="res://addons/easy_charts/examples/scatter_chart/scatter_chart_example.gd" id="1"]
+[ext_resource type="Theme" uid="uid://dtt7rfw0ictfw" path="res://addons/easy_charts/control_charts/dark_chart_theme.tres" id="1_72vbu"]
 [ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -11,13 +12,14 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control2" type="Control"]
+[node name="ScatterChartExample" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_72vbu")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd
+++ b/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd
@@ -13,12 +13,6 @@ func _ready():
 	# Let's customize the chart properties, which specify how the chart
 	# should look, plus some additional elements like labels, the scale, etc...
 	var cp: ChartProperties = ChartProperties.new()
-	cp.colors.frame = Color("#161a1d")
-	cp.colors.background = Color.TRANSPARENT
-	cp.colors.grid = Color("#283442")
-	cp.colors.ticks = Color("#283442")
-	cp.colors.text = Color.WHITE_SMOKE
-	cp.draw_bounding_box = false
 	cp.title = "Animal spots"
 	cp.x_label = "Time"
 	cp.y_label = "Spots"

--- a/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.tscn
+++ b/addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://duq43d7ll1aah"]
+[gd_scene load_steps=5 format=3 uid="uid://duq43d7ll1aah"]
 
 [ext_resource type="Script" uid="uid://cwjc16brbjkia" path="res://addons/easy_charts/examples/scatter_chart_discrete/scatter_chart_discrete.gd" id="1_3npap"]
+[ext_resource type="Theme" uid="uid://dtt7rfw0ictfw" path="res://addons/easy_charts/control_charts/dark_chart_theme.tres" id="1_pd01x"]
 [ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2_pd01x"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
@@ -11,13 +12,14 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control2" type="Control"]
+[node name="ScatterChartDiscreteExample" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_pd01x")
 script = ExtResource("1_3npap")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/simple_chart/simple_chart_example.tscn
+++ b/addons/easy_charts/examples/simple_chart/simple_chart_example.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://v4c2f17q8a1o"]
+[gd_scene load_steps=4 format=3 uid="uid://v4c2f17q8a1o"]
 
 [ext_resource type="Script" uid="uid://dikwjry6sb804" path="res://addons/easy_charts/examples/simple_chart/simple_chart_example.gd" id="1"]
+[ext_resource type="Theme" uid="uid://dbgw3bjtopyhv" path="res://addons/easy_charts/control_charts/default_chart_theme.tres" id="1_3o4eq"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 content_margin_right = 5.0
@@ -17,6 +18,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_3o4eq")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/simple_chart/simple_chart_example.tscn
+++ b/addons/easy_charts/examples/simple_chart/simple_chart_example.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://v4c2f17q8a1o"]
+[gd_scene load_steps=4 format=3 uid="uid://v4c2f17q8a1o"]
 
 [ext_resource type="Script" uid="uid://dikwjry6sb804" path="res://addons/easy_charts/examples/simple_chart/simple_chart_example.gd" id="1"]
+[ext_resource type="Theme" uid="uid://dwbt0h7cp3cg5" path="res://addons/easy_charts/control_charts/default_chart_theme.tres" id="1_3o4eq"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 content_margin_right = 5.0
@@ -10,13 +11,14 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control3" type="Control"]
+[node name="SimpleChartExample" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme = ExtResource("1_3o4eq")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/simple_chart/simple_chart_example.tscn
+++ b/addons/easy_charts/examples/simple_chart/simple_chart_example.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=4 format=3 uid="uid://v4c2f17q8a1o"]
+[gd_scene load_steps=3 format=3 uid="uid://v4c2f17q8a1o"]
 
 [ext_resource type="Script" uid="uid://dikwjry6sb804" path="res://addons/easy_charts/examples/simple_chart/simple_chart_example.gd" id="1"]
-[ext_resource type="Theme" uid="uid://dbgw3bjtopyhv" path="res://addons/easy_charts/control_charts/default_chart_theme.tres" id="1_3o4eq"]
 
 [sub_resource type="StyleBoxFlat" id="1"]
 content_margin_right = 5.0
@@ -11,14 +10,13 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0, 0, 0, 1)
 
-[node name="Control2" type="Control"]
+[node name="Control3" type="Control"]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme = ExtResource("1_3o4eq")
 script = ExtResource("1")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/easy_charts/examples/theming/theming_example.gd
+++ b/addons/easy_charts/examples/theming/theming_example.gd
@@ -1,0 +1,11 @@
+extends Panel
+
+@onready var _chart: Chart = %Chart
+
+func _ready():
+	var x: Array = ArrayOperations.multiply_float(range(-10, 11, 1), 0.5)
+	var y: Array = ArrayOperations.multiply_int(ArrayOperations.cos(x), 20)
+	var f1 = Function.new(x, y, "Pressure", { marker = Function.Marker.CIRCLE })
+
+	_chart.set_y_domain(-50, 50)
+	_chart.plot([f1])

--- a/addons/easy_charts/examples/theming/theming_example.gd
+++ b/addons/easy_charts/examples/theming/theming_example.gd
@@ -1,11 +1,40 @@
 extends Panel
 
-@onready var _chart: Chart = %Chart
+@onready var _vbox_container: Container = $MarginContainer/VBoxContainer
+@onready var _theme_options_button: OptionButton = %ThemeOptionButton
 
-func _ready():
+var _chart_scene := preload("res://addons/easy_charts/control_charts/chart.tscn")
+var _chart: Chart
+
+func _ready() -> void:
+	_theme_options_button.item_selected.connect(_on_theme_option_button_item_selected)
+	_theme_options_button.selected = 0
+	_on_theme_option_button_item_selected(_theme_options_button.selected)
+
+func _draw_chart() -> void:
+	if _chart != null:
+		_vbox_container.remove_child(_chart)
+		_chart.queue_free()
+		_chart = null
+
 	var x: Array = ArrayOperations.multiply_float(range(-10, 11, 1), 0.5)
 	var y: Array = ArrayOperations.multiply_int(ArrayOperations.cos(x), 20)
-	var f1 = Function.new(x, y, "Pressure", { marker = Function.Marker.CIRCLE })
+	var color: Color = Color.DARK_BLUE
+	if _theme_options_button.selected == 1 || _theme_options_button.selected == 3:
+		color = Color.GREEN
+	var f = Function.new(x, y, "Pressure", { color = color, marker = Function.Marker.CIRCLE })
 
+	_chart = _chart_scene.instantiate()
+	_vbox_container.add_child(_chart)
 	_chart.set_y_domain(-50, 50)
-	_chart.plot([f1])
+	_chart.plot([f])
+
+func _on_theme_option_button_item_selected(index: int) -> void:
+	var selected_theme: Theme
+	match index:
+		0: selected_theme = load("res://addons/easy_charts/control_charts/default_chart_theme.tres")
+		1: selected_theme = load("res://addons/easy_charts/control_charts/dark_chart_theme.tres")
+		2: selected_theme = load("res://addons/easy_charts/examples/theming/theming_example_blue.tres")
+		3: selected_theme = load("res://addons/easy_charts/examples/theming/theming_example_funny.tres")
+	theme = selected_theme
+	_draw_chart()

--- a/addons/easy_charts/examples/theming/theming_example.gd.uid
+++ b/addons/easy_charts/examples/theming/theming_example.gd.uid
@@ -1,0 +1,1 @@
+uid://c2mn4bclpax8f

--- a/addons/easy_charts/examples/theming/theming_example.tres
+++ b/addons/easy_charts/examples/theming/theming_example.tres
@@ -1,0 +1,37 @@
+[gd_resource type="Theme" load_steps=4 format=3 uid="uid://bnljqbatun5ty"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rmy2u"]
+content_margin_left = 15.0
+content_margin_top = 15.0
+content_margin_right = 40.0
+content_margin_bottom = 15.0
+bg_color = Color(0.804952, 0.897866, 0.983278, 1)
+border_width_left = 8
+border_width_top = 8
+border_width_right = 8
+border_width_bottom = 8
+border_color = Color(0.94902, 0.709804, 0.498039, 1)
+corner_radius_top_left = 15
+corner_radius_top_right = 15
+corner_radius_bottom_right = 15
+corner_radius_bottom_left = 15
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_34bsk"]
+bg_color = Color(0.965029, 0.993437, 0.925249, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.404151, 0.682177, 0.940872, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y55k3"]
+bg_color = Color(0.984546, 0.984547, 0.984546, 1)
+
+[resource]
+Chart/colors/origin_color = Color(0.773454, 0, 0.180562, 1)
+Chart/colors/text_color = Color(0.106934, 0.279233, 0.46393, 1)
+Chart/colors/tick_color = Color(0.193865, 0.300887, 0.247212, 1)
+Chart/colors/tick_grid_line_color = Color(0.627451, 0.8, 0.254902, 1)
+Chart/styles/chart_area = SubResource("StyleBoxFlat_rmy2u")
+Chart/styles/plot_area = SubResource("StyleBoxFlat_34bsk")
+Panel/styles/panel = SubResource("StyleBoxFlat_y55k3")

--- a/addons/easy_charts/examples/theming/theming_example.tscn
+++ b/addons/easy_charts/examples/theming/theming_example.tscn
@@ -1,8 +1,10 @@
 [gd_scene load_steps=4 format=3 uid="uid://ca8dgkbl6jcuq"]
 
-[ext_resource type="Theme" uid="uid://bnljqbatun5ty" path="res://addons/easy_charts/examples/theming/theming_example.tres" id="1_20x4x"]
+[ext_resource type="Theme" uid="uid://dwbt0h7cp3cg5" path="res://addons/easy_charts/control_charts/default_chart_theme.tres" id="1_7liax"]
 [ext_resource type="Script" uid="uid://c2mn4bclpax8f" path="res://addons/easy_charts/examples/theming/theming_example.gd" id="1_j62b8"]
-[ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2_7liax"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_20x4x"]
+bg_color = Color(1, 1, 1, 1)
 
 [node name="ThemingExample" type="Panel"]
 anchors_preset = 15
@@ -10,7 +12,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme = ExtResource("1_20x4x")
+theme = ExtResource("1_7liax")
+theme_override_styles/panel = SubResource("StyleBoxFlat_20x4x")
 script = ExtResource("1_j62b8")
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
@@ -20,11 +23,43 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_vertical = 3
 theme_override_constants/margin_left = 15
 theme_override_constants/margin_top = 15
 theme_override_constants/margin_right = 15
 theme_override_constants/margin_bottom = 15
 
-[node name="Chart" parent="MarginContainer" instance=ExtResource("2_7liax")]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/PanelContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 4
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/PanelContainer/MarginContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer"]
+layout_mode = 2
+text = "Choos a theme:"
+
+[node name="ThemeOptionButton" type="OptionButton" parent="MarginContainer/VBoxContainer/PanelContainer/MarginContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+flat = true
+selected = 0
+item_count = 4
+popup/item_0/text = "Default"
+popup/item_0/id = 0
+popup/item_1/text = "Dark"
+popup/item_1/id = 1
+popup/item_2/text = "Blue"
+popup/item_2/id = 2
+popup/item_3/text = "Funny"
+popup/item_3/id = 3

--- a/addons/easy_charts/examples/theming/theming_example.tscn
+++ b/addons/easy_charts/examples/theming/theming_example.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=4 format=3 uid="uid://ca8dgkbl6jcuq"]
+
+[ext_resource type="Theme" uid="uid://bnljqbatun5ty" path="res://addons/easy_charts/examples/theming/theming_example.tres" id="1_20x4x"]
+[ext_resource type="Script" uid="uid://c2mn4bclpax8f" path="res://addons/easy_charts/examples/theming/theming_example.gd" id="1_j62b8"]
+[ext_resource type="PackedScene" uid="uid://dlwq4kmdb3bhs" path="res://addons/easy_charts/control_charts/chart.tscn" id="2_7liax"]
+
+[node name="ThemingExample" type="Panel"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_20x4x")
+script = ExtResource("1_j62b8")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 15
+theme_override_constants/margin_top = 15
+theme_override_constants/margin_right = 15
+theme_override_constants/margin_bottom = 15
+
+[node name="Chart" parent="MarginContainer" instance=ExtResource("2_7liax")]
+unique_name_in_owner = true
+layout_mode = 2

--- a/addons/easy_charts/examples/theming/theming_example_blue.tres
+++ b/addons/easy_charts/examples/theming/theming_example_blue.tres
@@ -1,37 +1,33 @@
-[gd_resource type="Theme" load_steps=4 format=3 uid="uid://bnljqbatun5ty"]
+[gd_resource type="Theme" load_steps=3 format=3 uid="uid://bnljqbatun5ty"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rmy2u"]
 content_margin_left = 15.0
 content_margin_top = 15.0
 content_margin_right = 40.0
 content_margin_bottom = 15.0
-bg_color = Color(0.804952, 0.897866, 0.983278, 1)
+bg_color = Color(0.513499, 0.746508, 0.951353, 1)
 border_width_left = 8
 border_width_top = 8
 border_width_right = 8
 border_width_bottom = 8
-border_color = Color(0.94902, 0.709804, 0.498039, 1)
+border_color = Color(0.246478, 0.508126, 0.848807, 1)
 corner_radius_top_left = 15
 corner_radius_top_right = 15
 corner_radius_bottom_right = 15
 corner_radius_bottom_left = 15
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_34bsk"]
-bg_color = Color(0.965029, 0.993437, 0.925249, 1)
+bg_color = Color(0.826829, 0.909094, 0.988475, 1)
 border_width_left = 1
 border_width_top = 1
 border_width_right = 1
 border_width_bottom = 1
-border_color = Color(0.404151, 0.682177, 0.940872, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y55k3"]
-bg_color = Color(0.984546, 0.984547, 0.984546, 1)
+border_color = Color(0.210852, 0.538651, 0.820464, 1)
 
 [resource]
 Chart/colors/origin_color = Color(0.773454, 0, 0.180562, 1)
-Chart/colors/text_color = Color(0.106934, 0.279233, 0.46393, 1)
-Chart/colors/tick_color = Color(0.193865, 0.300887, 0.247212, 1)
-Chart/colors/tick_grid_line_color = Color(0.627451, 0.8, 0.254902, 1)
+Chart/colors/text_color = Color(0.068957, 0.324306, 0.651482, 1)
+Chart/colors/tick_color = Color(0.146677, 0.233932, 0.465296, 1)
+Chart/colors/tick_grid_line_color = Color(0.407889, 0.473545, 0.699079, 1)
 Chart/styles/chart_area = SubResource("StyleBoxFlat_rmy2u")
 Chart/styles/plot_area = SubResource("StyleBoxFlat_34bsk")
-Panel/styles/panel = SubResource("StyleBoxFlat_y55k3")

--- a/addons/easy_charts/examples/theming/theming_example_funny.tres
+++ b/addons/easy_charts/examples/theming/theming_example_funny.tres
@@ -1,0 +1,33 @@
+[gd_resource type="Theme" load_steps=3 format=3 uid="uid://dw8xxsnyv66ff"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rmy2u"]
+content_margin_left = 15.0
+content_margin_top = 15.0
+content_margin_right = 40.0
+content_margin_bottom = 15.0
+bg_color = Color(0.974368, 0.902183, 0, 1)
+border_width_left = 8
+border_width_top = 8
+border_width_right = 8
+border_width_bottom = 8
+border_color = Color(0.94902, 0, 0.498039, 1)
+corner_radius_top_left = 15
+corner_radius_top_right = 15
+corner_radius_bottom_right = 15
+corner_radius_bottom_left = 15
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_34bsk"]
+bg_color = Color(0, 0, 1, 1)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0, 0, 0, 1)
+
+[resource]
+Chart/colors/origin_color = Color(0.773454, 0, 0.180562, 1)
+Chart/colors/text_color = Color(0.176787, 0.406573, 0.654812, 1)
+Chart/colors/tick_color = Color(0.193865, 0.300887, 0.247212, 1)
+Chart/colors/tick_grid_line_color = Color(0.627451, 0.8, 0.254902, 1)
+Chart/styles/chart_area = SubResource("StyleBoxFlat_rmy2u")
+Chart/styles/plot_area = SubResource("StyleBoxFlat_34bsk")

--- a/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
+++ b/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
@@ -92,6 +92,7 @@ func to_theme() -> Theme:
 	var chart_area := StyleBoxFlat.new()
 	chart_area.bg_color = colors.frame
 	chart_area.draw_center = draw_frame
+	chart_area.set_content_margin_all(15)
 	theme.set_stylebox("chart_area", "Chart", chart_area)
 
 	var plot_area := StyleBoxFlat.new()

--- a/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
+++ b/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
@@ -19,9 +19,15 @@ var y_ticklabel_space: float = 5
 var x_scale_type: int = 0
 var y_scale_type: int = 0
 
+## draw_frame is deprecated. Use a theme instead.
 var draw_frame: bool = true
+
+## draw_background is deprecated. Use a theme instead.
 var draw_background: bool = true
+
+## draw_bounding_box is deprecated. Use a theme instead.
 var draw_bounding_box: bool = true
+
 var draw_vertical_grid: bool = true
 var draw_horizontal_grid: bool = true
 var draw_ticks: bool = true
@@ -53,6 +59,7 @@ var smooth_domain: bool = false
 var max_samples: int = 100
 
 ## Dictionary of colors for all of the Chart elements.
+## Note: This is deprecated. Use a theme instead
 var colors: Dictionary = {
 	frame = Color.WHITE_SMOKE,
 	background = Color.WHITE,
@@ -72,3 +79,26 @@ func _init() -> void:
 
 func get_string_size(text: String) -> Vector2:
 	return font.get_string_size(text)
+
+## Converts theming related properties into a Theme.
+func to_theme() -> Theme:
+	var theme = Theme.new()
+	theme.default_font = font
+	theme.set_color("origin_color", "Chart", colors.origin)
+	theme.set_color("text_color", "Chart", colors.text)
+	theme.set_color("tick_color", "Chart", colors.ticks)
+	theme.set_color("tick_grid_line_color", "Chart", colors.grid)
+
+	var chart_area := StyleBoxFlat.new()
+	chart_area.bg_color = colors.frame
+	chart_area.draw_center = draw_frame
+	theme.set_stylebox("chart_area", "Chart", chart_area)
+
+	var plot_area := StyleBoxFlat.new()
+	plot_area.bg_color = colors.background
+	plot_area.draw_center = draw_background
+	plot_area.border_color = colors.bounding_box
+	plot_area.set_border_width_all(1 if draw_bounding_box else 0)
+	theme.set_stylebox("plot_area", "Chart", plot_area)
+
+	return theme

--- a/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
+++ b/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
@@ -19,7 +19,6 @@ var y_ticklabel_space: float = 5
 var x_scale_type: int = 0
 var y_scale_type: int = 0
 
-var draw_borders: bool = true
 var draw_frame: bool = true
 var draw_background: bool = true
 var draw_bounding_box: bool = true
@@ -57,7 +56,6 @@ var max_samples: int = 100
 var colors: Dictionary = {
 	frame = Color.WHITE_SMOKE,
 	background = Color.WHITE,
-	borders = Color.RED,
 	bounding_box = Color.BLACK,
 	grid = Color.GRAY,
 	ticks = Color.BLACK,

--- a/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
+++ b/addons/easy_charts/utilities/classes/plotting/chart_properties.gd
@@ -79,27 +79,3 @@ func _init() -> void:
 
 func get_string_size(text: String) -> Vector2:
 	return font.get_string_size(text)
-
-## Converts theming related properties into a Theme.
-func to_theme() -> Theme:
-	var theme = Theme.new()
-	theme.default_font = font
-	theme.set_color("origin_color", "Chart", colors.origin)
-	theme.set_color("text_color", "Chart", colors.text)
-	theme.set_color("tick_color", "Chart", colors.ticks)
-	theme.set_color("tick_grid_line_color", "Chart", colors.grid)
-
-	var chart_area := StyleBoxFlat.new()
-	chart_area.bg_color = colors.frame
-	chart_area.draw_center = draw_frame
-	chart_area.set_content_margin_all(15)
-	theme.set_stylebox("chart_area", "Chart", chart_area)
-
-	var plot_area := StyleBoxFlat.new()
-	plot_area.bg_color = colors.background
-	plot_area.draw_center = draw_background
-	plot_area.border_color = colors.bounding_box
-	plot_area.set_border_width_all(1 if draw_bounding_box else 0)
-	theme.set_stylebox("plot_area", "Chart", plot_area)
-
-	return theme

--- a/addons/easy_charts/utilities/containers/canvas/canvas.gd
+++ b/addons/easy_charts/utilities/containers/canvas/canvas.gd
@@ -10,32 +10,32 @@ func _ready():
     pass # Replace with function body.
 
 func prepare_canvas(chart_properties: ChartProperties) -> void:
-    
-    if chart_properties.draw_frame:
-        set_color(chart_properties.colors.frame)
-        set_frame_visible(true)
-    else:
-        set_frame_visible(false)
-    
-    if chart_properties.show_title:
-        update_title(chart_properties.title, chart_properties.colors.text)
-    else:
-        _title_lbl.hide()
-    
-    if chart_properties.show_x_label:
-        update_x_label(chart_properties.x_label, chart_properties.colors.text)
-    else:
-        _x_lbl.hide()
-    
-    if chart_properties.show_y_label:
-        update_y_label(chart_properties.y_label, chart_properties.colors.text, -90)
-    else:
-        _y_lbl.hide()
-    
-    if chart_properties.show_legend:
-        _legend.show()
-    else:
-        hide_legend()
+	
+	if chart_properties.draw_frame:
+		set_color(chart_properties.colors.frame)
+		set_frame_visible(true)
+	else:
+		set_frame_visible(false)
+	
+	if chart_properties.show_title:
+		update_title(chart_properties.title, get_theme_color("text_color", "Chart"))
+	else:
+		_title_lbl.hide()
+	
+	if chart_properties.show_x_label:
+		update_x_label(chart_properties.x_label, get_theme_color("text_color", "Chart"))
+	else:
+		_x_lbl.hide()
+	
+	if chart_properties.show_y_label:
+		update_y_label(chart_properties.y_label, get_theme_color("text_color", "Chart"), -90)
+	else:
+		_y_lbl.hide()
+	
+	if chart_properties.show_legend:
+		_legend.show()
+	else:
+		hide_legend()
 
 func update_title(text: String, color: Color, rotation: float = 0.0) -> void:
     _title_lbl.show()

--- a/addons/easy_charts/utilities/containers/canvas/canvas.gd
+++ b/addons/easy_charts/utilities/containers/canvas/canvas.gd
@@ -10,13 +10,15 @@ func _ready():
     pass # Replace with function body.
 
 func prepare_canvas(chart_properties: ChartProperties) -> void:
-	
-	if chart_properties.draw_frame:
-		set_color(chart_properties.colors.frame)
-		set_frame_visible(true)
-	else:
-		set_frame_visible(false)
-	
+
+	#if chart_properties.draw_frame:
+		#set_color(chart_properties.colors.frame)
+		#set_frame_visible(true)
+	#else:
+		#set_frame_visible(false)
+
+	add_theme_stylebox_override("panel", get_theme_stylebox("chart_area", "Chart"))
+
 	if chart_properties.show_title:
 		update_title(chart_properties.title, get_theme_color("text_color", "Chart"))
 	else:

--- a/addons/easy_charts/utilities/containers/canvas/canvas.gd
+++ b/addons/easy_charts/utilities/containers/canvas/canvas.gd
@@ -10,13 +10,6 @@ func _ready():
     pass # Replace with function body.
 
 func prepare_canvas(chart_properties: ChartProperties) -> void:
-
-	#if chart_properties.draw_frame:
-		#set_color(chart_properties.colors.frame)
-		#set_frame_visible(true)
-	#else:
-		#set_frame_visible(false)
-
 	add_theme_stylebox_override("panel", get_theme_stylebox("chart_area", "Chart"))
 
 	if chart_properties.show_title:

--- a/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
+++ b/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
@@ -68,7 +68,7 @@ func _draw_origin() -> void:
 	draw_line(Vector2(self.plot_box.position.x, yorigin), Vector2(self.plot_box.position.x + self.plot_box.size.x, yorigin), get_theme_color("origin_color", "Chart"), 1)
 	draw_string(
 		get_parent().chart_properties.font, Vector2(xorigin, yorigin) - Vector2(15, -15), "O", HORIZONTAL_ALIGNMENT_CENTER, -1, 
-		ThemeDB.fallback_font_size, get_theme_color("tick_label_color", "Chart"), TextServer.JUSTIFICATION_NONE, TextServer.DIRECTION_AUTO, TextServer.ORIENTATION_HORIZONTAL
+		ThemeDB.fallback_font_size, get_theme_color("text_color", "Chart"), TextServer.JUSTIFICATION_NONE, TextServer.DIRECTION_AUTO, TextServer.ORIENTATION_HORIZONTAL
 	)
 
 
@@ -103,7 +103,7 @@ func _draw_x_ticks() -> void:
 				HORIZONTAL_ALIGNMENT_CENTER,
 				-1,
 				ThemeDB.fallback_font_size,
-				get_theme_color("tick_label_color", "Chart"),
+				get_theme_color("text_color", "Chart"),
 				TextServer.JUSTIFICATION_NONE,
 				TextServer.DIRECTION_AUTO,
 				TextServer.ORIENTATION_HORIZONTAL
@@ -147,7 +147,7 @@ func _draw_y_ticks() -> void:
 				HORIZONTAL_ALIGNMENT_CENTER,
 				-1,
 				ThemeDB.fallback_font_size,
-				get_theme_color("tick_label_color", "Chart"),
+				get_theme_color("text_color", "Chart"),
 				TextServer.JUSTIFICATION_NONE,
 				TextServer.DIRECTION_AUTO,
 				TextServer.ORIENTATION_HORIZONTAL

--- a/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
+++ b/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
@@ -44,19 +44,28 @@ func _draw() -> void:
 		_draw_bounding_box()
 
 func _draw_background() -> void:
-	draw_rect(self.box, get_parent().chart_properties.colors.background, true)# false) TODOGODOT4 Antialiasing argument is missing
+	var style_box := get_theme_stylebox("plot_area", "Chart")
+	if style_box is StyleBoxFlat:
+		draw_rect(self.box, style_box.bg_color, true)# false) TODOGODOT4 Antialiasing argument is missing
+	else:
+		push_error("plot_area style box must be StyleBoxFlat")
 
 func _draw_bounding_box() -> void:
 	var box: Rect2 = self.box
 	box.position.y += 1
-	draw_rect(box, get_parent().chart_properties.colors.bounding_box, false, 1)# true) TODOGODOT4 Antialiasing argument is missing
+
+	var style_box := get_theme_stylebox("plot_area", "Chart")
+	if style_box is StyleBoxFlat:
+		draw_rect(box, style_box.border_color, false, 1)# true) TODOGODOT4 Antialiasing argument is missing
+	else:
+		push_error("plot_area style box must be StyleBoxFlat")
 
 func _draw_origin() -> void:
 	var xorigin: float = ECUtilities._map_domain(0.0, x_domain, ChartAxisDomain.from_bounds(self.plot_box.position.x, self.plot_box.end.x))
 	var yorigin: float = ECUtilities._map_domain(0.0, y_domain, ChartAxisDomain.from_bounds(self.plot_box.end.y, self.plot_box.position.y))
-		
-	draw_line(Vector2(xorigin, self.plot_box.position.y), Vector2(xorigin, self.plot_box.position.y + self.plot_box.size.y), get_parent().chart_properties.colors.origin, 1)
-	draw_line(Vector2(self.plot_box.position.x, yorigin), Vector2(self.plot_box.position.x + self.plot_box.size.x, yorigin), get_parent().chart_properties.colors.origin, 1)
+	
+	draw_line(Vector2(xorigin, self.plot_box.position.y), Vector2(xorigin, self.plot_box.position.y + self.plot_box.size.y), get_theme_color("origin_color", "Chart"), 1)
+	draw_line(Vector2(self.plot_box.position.x, yorigin), Vector2(self.plot_box.position.x + self.plot_box.size.x, yorigin), get_theme_color("origin_color", "Chart"), 1)
 	draw_string(
 		get_parent().chart_properties.font, Vector2(xorigin, yorigin) - Vector2(15, -15), "O", HORIZONTAL_ALIGNMENT_CENTER, -1, 
 		ThemeDB.fallback_font_size, get_theme_color("tick_label_color", "Chart"), TextServer.JUSTIFICATION_NONE, TextServer.DIRECTION_AUTO, TextServer.ORIENTATION_HORIZONTAL
@@ -112,10 +121,10 @@ func _draw_y_ticks() -> void:
 	var labels = y_domain.get_tick_labels()
 	var tick_count = labels.size()
 	var y_pixel_dist: float = self.plot_box.size.y / tick_count
-	
+
 	var horizontal_grid: PackedVector2Array = []
 	var horizontal_ticks: PackedVector2Array = []
-	
+
 	for i in range(tick_count):
 		var y_sampled_val: float = self.plot_box.size.y - (i * y_pixel_dist) + self.plot_box.position.y
 

--- a/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
+++ b/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
@@ -59,8 +59,8 @@ func _draw_origin() -> void:
 	draw_line(Vector2(self.plot_box.position.x, yorigin), Vector2(self.plot_box.position.x + self.plot_box.size.x, yorigin), get_parent().chart_properties.colors.origin, 1)
 	draw_string(
 		get_parent().chart_properties.font, Vector2(xorigin, yorigin) - Vector2(15, -15), "O", HORIZONTAL_ALIGNMENT_CENTER, -1, 
-		ThemeDB.fallback_font_size, get_parent().chart_properties.colors.text, TextServer.JUSTIFICATION_NONE, TextServer.DIRECTION_AUTO, TextServer.ORIENTATION_HORIZONTAL
-		)
+		ThemeDB.fallback_font_size, get_theme_color("tick_label_color", "Chart"), TextServer.JUSTIFICATION_NONE, TextServer.DIRECTION_AUTO, TextServer.ORIENTATION_HORIZONTAL
+	)
 
 
 func _draw_x_ticks() -> void:
@@ -94,7 +94,7 @@ func _draw_x_ticks() -> void:
 				HORIZONTAL_ALIGNMENT_CENTER,
 				-1,
 				ThemeDB.fallback_font_size,
-				get_parent().chart_properties.colors.text,
+				get_theme_color("tick_label_color", "Chart"),
 				TextServer.JUSTIFICATION_NONE,
 				TextServer.DIRECTION_AUTO,
 				TextServer.ORIENTATION_HORIZONTAL
@@ -138,7 +138,7 @@ func _draw_y_ticks() -> void:
 				HORIZONTAL_ALIGNMENT_CENTER,
 				-1,
 				ThemeDB.fallback_font_size,
-				get_parent().chart_properties.colors.text,
+				get_theme_color("tick_label_color", "Chart"),
 				TextServer.JUSTIFICATION_NONE,
 				TextServer.DIRECTION_AUTO,
 				TextServer.ORIENTATION_HORIZONTAL

--- a/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
+++ b/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
@@ -102,11 +102,11 @@ func _draw_x_ticks() -> void:
 
 	# Draw x grid
 	if get_parent().chart_properties.draw_vertical_grid:
-		draw_multiline(vertical_grid, get_parent().chart_properties.colors.grid, 1)
+		draw_multiline(vertical_grid, get_theme_color("tick_grid_line_color", "Chart"), 1)
 
 	# Draw x ticks
 	if get_parent().chart_properties.draw_ticks:
-		draw_multiline(vertical_ticks, get_parent().chart_properties.colors.ticks, 1)
+		draw_multiline(vertical_ticks, get_theme_color("tick_color", "Chart"), 1)
 
 func _draw_y_ticks() -> void:
 	var labels = y_domain.get_tick_labels()
@@ -146,11 +146,11 @@ func _draw_y_ticks() -> void:
 	
 	# Draw y grid
 	if get_parent().chart_properties.draw_horizontal_grid:
-		draw_multiline(horizontal_grid, get_parent().chart_properties.colors.grid, 1)
+		draw_multiline(horizontal_grid, get_theme_color("tick_grid_line_color", "Chart"), 1)
 	
 	# Draw y ticks
 	if get_parent().chart_properties.draw_ticks:
-		draw_multiline(horizontal_ticks, get_parent().chart_properties.colors.ticks, 1)
+		draw_multiline(horizontal_ticks, get_theme_color("tick_color", "Chart"), 1)
 		
 
 func _get_x_tick_label_position(base_position: Vector2, text: String) -> Vector2:

--- a/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
+++ b/addons/easy_charts/utilities/containers/canvas/plot_box/grid_box.gd
@@ -47,8 +47,10 @@ func _draw_background() -> void:
 	var style_box := get_theme_stylebox("plot_area", "Chart")
 	if style_box is StyleBoxFlat:
 		draw_rect(self.box, style_box.bg_color, true)# false) TODOGODOT4 Antialiasing argument is missing
+	elif style_box is StyleBoxEmpty:
+		return
 	else:
-		push_error("plot_area style box must be StyleBoxFlat")
+		push_error("plot_area style box must be StyleBoxFlat or StyleBoxEmpty")
 
 func _draw_bounding_box() -> void:
 	var box: Rect2 = self.box
@@ -57,8 +59,10 @@ func _draw_bounding_box() -> void:
 	var style_box := get_theme_stylebox("plot_area", "Chart")
 	if style_box is StyleBoxFlat:
 		draw_rect(box, style_box.border_color, false, 1)# true) TODOGODOT4 Antialiasing argument is missing
+	elif style_box is StyleBoxEmpty:
+		return
 	else:
-		push_error("plot_area style box must be StyleBoxFlat")
+		push_error("plot_area style box must be StyleBoxFlat or StyleBoxEmpty")
 
 func _draw_origin() -> void:
 	var xorigin: float = ECUtilities._map_domain(0.0, x_domain, ChartAxisDomain.from_bounds(self.plot_box.position.x, self.plot_box.end.x))

--- a/addons/easy_charts/utilities/containers/legend/function_label.gd
+++ b/addons/easy_charts/utilities/containers/legend/function_label.gd
@@ -11,7 +11,7 @@ func init_label(function: Function) -> void:
 	type_lbl.color = function.get_color()
 	type_lbl.marker = function.get_marker()
 	name_lbl.text = function.name
-	name_lbl.set("theme_override_colors/font_color", get_parent().chart_properties.colors.text)
+	name_lbl.set("theme_override_colors/font_color", get_theme_color("text_color", "Chart"))
 
 	type_lbl.indicator_visible = function.get_visibility()
 	function.visibility_changed.connect(_on_function_visibilty_changed)
@@ -21,7 +21,7 @@ func init_clabel(type: int, color: Color, marker: int, name: String) -> void:
 	type_lbl.color = color
 	type_lbl.marker = marker
 	name_lbl.set_text(name)
-	name_lbl.set("theme_override_colors/font_color", get_parent().chart_properties.colors.text)
+	name_lbl.set("theme_override_colors/font_color", get_theme_color("text_color", "Chart"))
 
 func _gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:

--- a/addons/easy_charts/utilities/containers/legend/function_label.gd
+++ b/addons/easy_charts/utilities/containers/legend/function_label.gd
@@ -10,7 +10,7 @@ func init_label(function: Function) -> void:
 	type_lbl.type = function.get_type()
 	type_lbl.color = function.get_color()
 	type_lbl.marker = function.get_marker()
-	name_lbl.set_text(function.name)
+	name_lbl.text = function.name
 	name_lbl.set("theme_override_colors/font_color", get_parent().chart_properties.colors.text)
 
 	type_lbl.indicator_visible = function.get_visibility()


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR allows to style charts via `Theme`s. This gives some more flexibility, e.g adding borders with corner radius etc.

Two themes are provided as part of the control charts:

- Default (`addons/easy_charts/control_charts/default_chart_theme.tres`): Default, light theme. The color settings have been taken from the default values in `ChartProperties`.
- Dark (`addons/easy_charts/control_charts/dark_chart_theme.tres`): A dark theme that is used by the examples (except for the `simple_chart` example which uses the default theme).

For guidance, two more themes (dark and funny) are provided as part of the `theming_example`. This example allows to switch between default, dark, blue and funny (see screenshots below).

**Is this change backwards compatible?** Yes, existing users can continue to style via `ChartProperties`. This works because the `Chart` creates a new `Theme` resource when drawn. This theme is filled by values from outer `Theme`s if available (e.g. when declared on a parent control node). Values that are not provided by any parent theme are initialized with values from `ChartProperties`. Right now, although discouraged, this would even allow to specify some values in a `Theme` and others in `ChartProperties`.

**Can a theme be switched at runtime?** Switching themes of a chart at runtime does not fully work right now. You either have to re-draw the chart or replace it with a new instance. This can be fixed as soon as we remove the backwards compatibility with `ChartProperties` because it is caused by the process described above.

**What styling is missing?** You cannot fully style the `GridBox` / plot area yet because the background and borders are drawn via calls to `draw_rect()`. A future PR can change this and use a `Panel` instead to get the full set of features. Attention must be paid to correctly respect offsets introduced by any style box. To be future proof, the plot area styles are defined by a style box, but only `bg_color` and `border_color` properties have any effect.

## What is the current behavior?

The `ChartProperties` allow for a limited set of customization.

## What is the new behavior?

Allow for more customization.

## Additional context

Screenshots from the `theming_example`:

<img width="2252" height="1520"  alt="Screenshot of a chart using the default theme" src="https://github.com/user-attachments/assets/710e50d1-ff8d-4b12-a07d-2aea18b57380" />

<img width="2252" height="1520" alt="Screenshot of a chart using the dark theme" src="https://github.com/user-attachments/assets/f189e325-7f11-419f-a671-775b41f5409e" />

<img width="2252" height="1520" alt="Screenshot of a chart using the blue theme" src="https://github.com/user-attachments/assets/ebd67113-f4c4-4e59-86c7-a88bfcc743b4" />

<img width="2252" height="1520" alt="Screenshot of a chart using the funny theme" src="https://github.com/user-attachments/assets/40a6f740-9ff5-4d2d-a542-49678a47d7f9" />


