### PR TITLE
Fix max_samples and keep bar chart rendering

### DIFF
--- a/addons/easy_charts/control_charts/chart.gd
+++ b/addons/easy_charts/control_charts/chart.gd
@@ -94,9 +94,11 @@ func _draw() -> void:
 
 	# GridBox
 	if not is_x_fixed or not is_y_fixed :
+		var _x: Array = x
+		var _y: Array = y
 		if chart_properties.max_samples > 0 :
-			var _x: Array = []
-			var _y: Array = []
+			_x = []
+			_y = []
 
 			_x.resize(x.size())
 			_y.resize(y.size())
@@ -107,16 +109,17 @@ func _draw() -> void:
 				if not is_y_fixed:
 					_y[i] = y[i].slice(max(0, y[i].size() - chart_properties.max_samples), y[i].size())
 
-			if not is_x_fixed:
-				x_domain = ChartAxisDomain.from_values(_x, chart_properties.smooth_domain)
-			if not is_y_fixed:
-				y_domain = ChartAxisDomain.from_values(_y, chart_properties.smooth_domain)
-		else:
-			if not is_x_fixed:
-				x_domain = ChartAxisDomain.from_values(x, chart_properties.smooth_domain)
-			if not is_y_fixed:
-				y_domain = ChartAxisDomain.from_values(y, chart_properties.smooth_domain)
-	
+		# Ensure that zero is available on the y-axis in case of we have at least one
+		# bar chart function. This is a dirty hack to ensure that bars are not drawn below
+		# the x-axis / x-axis tick labels.
+		if get_functions_by_type(Function.Type.BAR).size() > 0:
+			_y.append([0])
+
+		if not is_x_fixed:
+			x_domain = ChartAxisDomain.from_values(_x, chart_properties.smooth_domain)
+		if not is_y_fixed:
+			y_domain = ChartAxisDomain.from_values(_y, chart_properties.smooth_domain)
+
 	if !x_domain.is_discrete:
 		x_domain.set_tick_count(chart_properties.x_scale)
 

--- a/addons/easy_charts/control_charts/domain/chart_axis_domain.gd
+++ b/addons/easy_charts/control_charts/domain/chart_axis_domain.gd
@@ -49,13 +49,13 @@ static func from_values(value_arrays: Array, smooth_domain: bool) -> ChartAxisDo
 
 	var min_max: Dictionary = ECUtilities._find_min_max(value_arrays)
 	if not smooth_domain:
-		domain.lb = min(0.0, min_max.min)
+		domain.lb = min_max.min
 		domain.ub = min_max.max
 		domain.has_decimals = ECUtilities._has_decimals(value_arrays)
 		domain.is_discrete = false
 		domain.fixed = false
 	else:
-		domain.lb = ECUtilities._round_min(min(0.0, min_max.min))
+		domain.lb = ECUtilities._round_min(min_max.min)
 		domain.ub = ECUtilities._round_max(min_max.max)
 		domain.has_decimals = ECUtilities._has_decimals(value_arrays)
 		domain.is_discrete = false


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a bugfix for the regression that was reported by @CsloudX in https://github.com/fenix-hub/godot-engine.easy-charts/issues/97#issuecomment-3477494595 .

## What is the current behavior?

The current behavior does not update the chart axis domains correctly when having more data then `max_samples`. This regression was introduced by #121. In #121, a fix was added to ensure that bar charts always start properly at zero (cf. #94).

## What is the new behavior?

I reverted the min/max calculation in the `ChartAxisDomain`. This fixes the live-data examples that now properly update the domains if `max_samples` is exceeded.

I also introduced a hack to ensure that charts that have at least one bar chart always include the value `0` in the y-axis domain.
