### PR TITLE
Fix draw_rect warnings by removing width arguments + provide a boolean for 'filled'

### DIFF
--- a/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
+++ b/addons/easy_charts/control_charts/plotters/scatter_plotter.gd
@@ -62,7 +62,7 @@ func draw_function_point(point_position: Vector2) -> void:
 		Function.Marker.SQUARE:
 			draw_rect(
 				Rect2(point_position - (Vector2.ONE * _point_size), (Vector2.ONE * _point_size * 2)), 
-				function.get_color(), true, 1.0
+				function.get_color(), true
 			)
 		Function.Marker.TRIANGLE:
 			draw_colored_polygon(

--- a/addons/easy_charts/utilities/containers/legend/function_type.gd
+++ b/addons/easy_charts/utilities/containers/legend/function_type.gd
@@ -41,7 +41,7 @@ func _draw_function_and_marker() -> void:
 					Vector2(get_rect().end.x, get_rect().end.y / 2)
 				),
 				color_light,
-				3
+				true
 			)
 			draw_line(
 				Vector2(get_rect().position.x, center.y),
@@ -53,7 +53,7 @@ func _draw_function_and_marker() -> void:
 			draw_rect(
 				Rect2(center - (Vector2.ONE * 3), (Vector2.ONE * 3 * 2)),
 				color,
-				1.0
+				true
 			)
 		Function.Type.BAR:
 			draw_rect(
@@ -62,7 +62,7 @@ func _draw_function_and_marker() -> void:
 					Vector2(get_rect().end.x, get_rect().end.y)
 				),
 				color,
-				3
+				true
 			)
 		Function.Type.SCATTER, _:
 			pass
@@ -73,7 +73,8 @@ func _draw_function_and_marker() -> void:
 		Function.Marker.SQUARE:
 			draw_rect(
 				Rect2(center - (Vector2.ONE * 3), (Vector2.ONE * 3 * 2)), 
-				color, 1.0
+				color,
+				true
 			)
 		Function.Marker.TRIANGLE:
 			draw_colored_polygon(


### PR DESCRIPTION
## What kind of change does this PR introduce?

In this comment https://github.com/fenix-hub/godot-engine.easy-charts/issues/106#issuecomment-3477500329, @csloudx reported some more `The draw_rect() "width" argument has no effect when "filled" is "true"` warnings. They originate from the `ScatterPlotter` class.

## What is the current behavior?

Above warning is printed.

## What is the new behavior?

The warning is gone. In addition, I also changed the parameters passed for the `filled` argument of all `draw_rect` calls to be a boolean.