### PR TITLE
fix drawing plots with constant value

### DIFF
--- a/addons/easy_charts/control_charts/domain/chart_axis_domain.gd
+++ b/addons/easy_charts/control_charts/domain/chart_axis_domain.gd
@@ -21,6 +21,9 @@ var fixed: bool
 ## Callable to overwrite the label generation.
 var labels_function: Callable
 
+# axis size used when all values in from_values() call are equal
+var epsilon = 0.00001
+
 var _tick_count: int = -1
 
 var _string_values: Array
@@ -60,6 +63,8 @@ static func from_values(value_arrays: Array, smooth_domain: bool) -> ChartAxisDo
 		domain.has_decimals = ECUtilities._has_decimals(value_arrays)
 		domain.is_discrete = false
 		domain.fixed = false
+	if domain.lb == domain.ub:
+		domain.ub += domain.epsilon
 
 	return domain
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Creating plot from constant function (all values are equal) results empty plot due to issue with range of y-axis

![current](https://github.com/user-attachments/assets/b1da72a4-1c62-468f-b1a2-8bbc25f03c0e)

## What is the new behavior?

This PR fixed this by setting `domain.ub` to a greater value than `domain.lb`. Range of axis for constant value can be configurable via `domain.epsilon`

![fixed](https://github.com/user-attachments/assets/1f9741cb-a492-4e21-8996-ae32087bb1d9)
