### PR TITLE
Imporove chart theming fallback handling

### DIFF
--- a/addons/easy_charts/control_charts/chart.gd
+++ b/addons/easy_charts/control_charts/chart.gd
@@ -212,14 +212,24 @@ func _on_function_legend_function_clicked(function: Function) -> void:
 	function.toggle_visibility()
 	queue_redraw()
 
+# The _init_theme() method ensures that all styling properties are
+# available via Godot's theming engine. Note: This also handles theming
+# via ChartProperties (which is deprecated).
 func _init_theme(chart_properties: ChartProperties) -> void:
-	if theme:
-		return
+	# We need to assign a theme, so that we can add missing theme properties.
+	# If a theme exists on the node, missing properties will be added.
+	# This allows users to partially overwrite the default theme (e.g. only the label color
+	# with the rest of the styling being derived from the default style).
+	if theme == null:
+		theme = Theme.new()
 
 	_warn_about_deprecated_chart_properties_styling_if_required()
 
-	theme = _get_theme_from_properties(chart_properties)
+	_init_missing_theming_properties_with_defaults(chart_properties)
 
+# Push a warning in case that users use ChartProperties for styling.
+# This is done by detecting if styling related ChartProperties differ
+# from their default values.
 func _warn_about_deprecated_chart_properties_styling_if_required():
 	var default_theme: Theme = load("res://addons/easy_charts/control_charts/default_chart_theme.tres")
 	var is_color_different = func (col1, col2): return col1.to_html() != col2.to_html()
@@ -246,9 +256,12 @@ func _warn_about_deprecated_chart_properties_styling_if_required():
 		" This is deprecated and will be removed in future. " +
 		" Please use a Theme. Refer to: https://www.nicolosantilio.it/godot-engine.easy-charts/theming/")
 
-
-func _get_theme_from_properties(chart_properties: ChartProperties) -> Theme:
-	var theme = Theme.new()
+# Assign missing styling properties to the theme of the Chart node.
+#
+# Note: This function right now uses the ChartProperties to assign missing
+# theme properties. In future, when styling related ChartProperties are removed
+# this should be changed to use the values from the default_chart_theme.tres.
+func _init_missing_theming_properties_with_defaults(chart_properties: ChartProperties):
 	theme.default_font = chart_properties.font
 	
 	if !has_theme_color("origin_color", "Chart"):
@@ -277,5 +290,3 @@ func _get_theme_from_properties(chart_properties: ChartProperties) -> Theme:
 		plot_area.border_color = chart_properties.colors.bounding_box
 		plot_area.set_border_width_all(1 if chart_properties.draw_bounding_box else 0)
 		theme.set_stylebox("plot_area", "Chart", plot_area)
-
-	return theme


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR hardens the theme fallback handling. It covers the bug filed in #153, too.

## What is the current and new  behavior?

### Fixed: No longer overwriting theme on every `Chart.plot()` call

Right now, the theme is overwritten every time that `Chart.plot()` is called. This leads to "flickering" behavior, as the theme fallback handling replaces the theme assigned to the `Chart` with altering values.

### Fixed: Assigning a `Theme` to the `Chart` node directly works now

Right now, any theme assigned to the `Chart` node was overwritten by a theme generated by the `Chart` node. This means, that assigning a theme to the `Chart` had no effect. Users had to set the theme to a parent node to make it work correctly. This is now fixed (see details below).

### Improved: Merging of themes

The PR also improves the theme "merging" (I call it that way, although themes are not merged by us in code but handled by the Godot theming engine just as expected). This includes handling (deprecated) style properties in `ChartProperties`.

Example:

- A theme on any parent node of a `Chart` can partially set the Chart theme (e.g. user sets the `plot_area` style box only).
- A theme on the `Chart` node itself can partially set the Chart theme, too (e.g. user sets `chart_area` style box only).
- `ChartProperties` can be used to set additional theming overwrites  (e.g. sets the `ChartProperties.colors.text` only).
- Finally, any property still missing is initialized with their default value.

In this case, the `plot_area` is styled by the parent node, the `chart_area` is styled by the theme of the `Chart`, the label color is styled via `ChartProperties` and the remaining styling properties get a default fallback value.

(Hope that makes sense, it is a bit hard to explain :) )
