### PR TITLE
Fix _get return type for Godot 4.7

### DIFF
--- a/addons/easy_charts/utilities/classes/structures/data_frame.gd
+++ b/addons/easy_charts/utilities/classes/structures/data_frame.gd
@@ -160,11 +160,11 @@ func get_irows(indexes : PackedInt32Array) -> Array:
 # dataset["0:5"] ---> Returns an array containing all columns from the 1st to the 4th
 # dataset["label0;label5"] ---> Returns an array containing all row from the one with label == "label0" to the one with label == "label5"
 # dataset["header0:header0"] ---> Returns an array containing all columns from the one with label == "label0" to the one with label == "label5"
-func _get(_property : StringName):
-	# ":" --> Columns 
+func _get(_property : StringName) -> Variant:
+	# ":" --> Columns
 	if ":" in _property:
 		var property : PackedStringArray = _property.split(":")
-		if (property[0]).is_valid_int(): 
+		if (property[0]).is_valid_int():
 			if property[1] == "*":
 				return get_icolumns(range(property[0] as int, headers.size()-1))
 			else:
@@ -173,18 +173,20 @@ func _get(_property : StringName):
 			if property[1] == "*":
 				return get_icolumns(range(get_column_index(property[0]), headers.size()-1))
 			else:
-				return get_icolumns(range(get_column_index(property[0]), get_column_index(property[1])))    
-	# ";" --> Rows 
+				return get_icolumns(range(get_column_index(property[0]), get_column_index(property[1])))
+	# ";" --> Rows
 	elif ";" in _property:
 		var property : PackedStringArray = _property.split(";")
-		if (property[0]).is_valid_int(): 
+		if (property[0]).is_valid_int():
 			return get_irows(range(property[0] as int, property[1] as int + 1 ))
-		else: 
+		else:
 			return get_irows(range(get_row_index(property[0]), get_row_index(property[1])))
 	elif "," in _property:
 		var property : PackedStringArray = _property.split(",")
+		return null
 	else:
 		if (_property as String).is_valid_int():
 			return get_icolumn(int(_property))
 		else:
 			return get_column(_property)
+	return null

--- a/addons/easy_charts/utilities/classes/structures/matrix.gd
+++ b/addons/easy_charts/utilities/classes/structures/matrix.gd
@@ -159,10 +159,10 @@ func set(position: StringName, value: Variant) -> void:
 	values[t_pos[0]][t_pos[1]] = value
 
 # --------------
-func _get(_property : StringName):
-	# ":" --> Columns 
+func _get(_property : StringName) -> Variant:
+	# ":" --> Columns
 	if ":" in _property:
-		var property : PackedStringArray = _property.split(":") 
+		var property : PackedStringArray = _property.split(":")
 		var from : PackedStringArray = property[0].split(",")
 		var to : PackedStringArray = property[1].split(",")
 	elif "," in _property:
@@ -172,3 +172,4 @@ func _get(_property : StringName):
 	else:
 		if (_property as String).is_valid_int():
 			return get_row(int(_property))
+	return null


### PR DESCRIPTION
Add -> Variant return type annotation and ensure all code paths return in matrix.gd and data_frame.gd _get functions to satisfy Godot 4.7's stricter return type checking.

## What kind of change does this PR introduce?

update typing because 4.7 introduced stricter return type checkign

## What is the current behavior?

using easy charts in editor produces engine errors 

## What is the new behavior?

no more engine errors 

## Additional context

Add any other context or screenshots.
